### PR TITLE
feat: add Claude Code best practices to /learn command

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ After plugin install, commands are namespaced:
 | `/pro-workflow:wrap-up` | End-of-session checklist |
 | `/pro-workflow:learn-rule` | Extract correction to memory (file-based) |
 | `/pro-workflow:parallel` | Worktree setup guide |
-| `/pro-workflow:learn` | **NEW** Save learning to SQLite database |
+| `/pro-workflow:learn` | **NEW** Claude Code best practices & save learnings |
 | `/pro-workflow:search` | **NEW** Search learnings by keyword |
 | `/pro-workflow:list` | **NEW** List all stored learnings |
 
@@ -139,6 +139,8 @@ Learnings are stored in SQLite with FTS5 full-text search:
 - Context (when to clarify)
 - Architecture (design decisions)
 - Performance (optimization)
+- Claude-Code (sessions, modes, CLAUDE.md, skills, subagents, hooks, MCP)
+- Prompting (scope, constraints, acceptance criteria)
 
 ## Hooks
 
@@ -185,7 +187,7 @@ pro-workflow/
 │   ├── plugin.json           # Plugin manifest
 │   ├── marketplace.json      # Marketplace config
 │   └── README.md
-├── src/                      # TypeScript source (NEW)
+├── src/                      # TypeScript source
 │   ├── db/
 │   │   ├── index.ts          # Database initialization
 │   │   ├── store.ts          # Stateless store factory
@@ -198,29 +200,45 @@ pro-workflow/
 │   └── pro-workflow/
 │       └── SKILL.md          # Main skill
 ├── agents/
-│   ├── planner.md
-│   └── reviewer.md
+│   ├── planner.md            # Planner agent
+│   └── reviewer.md           # Reviewer agent
 ├── commands/
-│   ├── wrap-up.md
-│   ├── learn-rule.md
-│   ├── parallel.md
-│   ├── learn.md              # NEW
-│   ├── search.md             # NEW
-│   └── list.md               # NEW
+│   ├── wrap-up.md # Wrap-up command
+│   ├── learn-rule.md # Learn rule command
+│   ├── parallel.md # Parallel command
+│   ├── learn.md
+│   ├── search.md # Search command
+│   └── list.md # List command
 ├── hooks/
-│   └── hooks.json
+│   └── hooks.json # Hooks file
 ├── scripts/                  # Hook scripts
 ├── contexts/
-│   ├── dev.md
-│   ├── review.md
-│   └── research.md
+│   ├── dev.md # Dev context
+│   ├── review.md # Review context
+│   └── research.md # Research context
+├── references/
+│   └── claude-code-resources.md # Claude code resources reference file
 ├── rules/
-│   └── core-rules.md
+│   └── core-rules.md # Core rules file
 ├── templates/
-│   └── split-claude-md/
-├── package.json              # NEW
-├── tsconfig.json             # NEW
-└── README.md
+│   └── split-claude-md/ # Split claude md template
+├── package.json
+├── tsconfig.json # TypeScript configuration file
+└── README.md # README file
+```
+
+## Learn Claude Code
+
+Pro-workflow teaches Claude Code best practices directly, with links to official documentation for deep dives.
+
+**Official Docs:** https://code.claude.com/docs/
+
+Topics covered: sessions, context management, modes, CLAUDE.md, prompting, writing rules, skills, subagents, hooks, MCP, security, and IDE integration.
+
+```
+/pro-workflow:learn                 # Best practices guide & save learnings
+/pro-workflow:learn-rule            # Capture corrections to memory
+/pro-workflow:search claude-code    # Find past Claude Code learnings
 ```
 
 ## SkillKit - Universal AI Skills

--- a/commands/learn-rule.md
+++ b/commands/learn-rule.md
@@ -20,6 +20,10 @@ Capture a lesson from this session into permanent memory.
    - Git (commits, branches)
    - Quality (lint, types, style)
    - Context (when to clarify)
+   - Architecture (design decisions)
+   - Performance (optimization)
+   - Claude-Code (sessions, modes, CLAUDE.md, skills, subagents, hooks, MCP)
+   - Prompting (scope, constraints, acceptance criteria)
 
 3. **Propose addition**
    Show what will be added to LEARNED section.
@@ -35,6 +39,20 @@ Recent mistake: Edited wrong utils.ts file
 [LEARN] Navigation: Confirm full path when multiple files share a name.
 
 Add to LEARNED section? (y/n)
+```
+
+---
+
+## Claude Code Examples
+
+```
+[LEARN] Claude-Code: Use plan mode before multi-file changes.
+Docs: https://code.claude.com/docs/common-workflows
+
+[LEARN] Claude-Code: Compact context at task boundaries, not mid-work.
+Docs: https://code.claude.com/docs/common-workflows
+
+[LEARN] Prompting: Always include acceptance criteria in prompts.
 ```
 
 ---

--- a/commands/learn.md
+++ b/commands/learn.md
@@ -1,50 +1,147 @@
-# /learn - Save Learning to Database
+# /learn - Claude Code Best Practices & Learning Capture
 
-Capture a lesson from this session into the persistent SQLite database.
+Learn Claude Code best practices and capture lessons into persistent memory.
 
-## Process
+## Usage
 
-1. **Identify the learning**
-   - What mistake was made?
-   - What should happen instead?
-   - What category does this fall under?
+- `/learn` — Show best practices guide
+- `/learn <topic>` — Show practices for a specific topic (e.g., `/learn context`, `/learn prompting`)
+- `/learn save` — Capture a lesson from this session into the database
 
-2. **Categories**
-   - Navigation (file paths, finding code)
-   - Editing (code changes, patterns)
-   - Testing (test approaches)
-   - Git (commits, branches)
-   - Quality (lint, types, style)
-   - Context (when to clarify)
-   - Architecture (design decisions)
-   - Performance (optimization)
+## Best Practices
 
-3. **Save to database**
-   Use this format to save:
-   ```
-   Category: <category>
-   Rule: <one-line description of the correct behavior>
-   Mistake: <what went wrong>
-   Correction: <how it was fixed>
-   ```
+### Sessions & Context
+- Every Claude Code invocation is a session. Claude reads your project on start.
+- Context window is finite (200k tokens). Use `/context` to check usage.
+- Use `/compact` at task boundaries — after planning, after a feature, when >70%.
+- Don't compact mid-task. You lose working context.
+- **Docs:** https://code.claude.com/docs/common-workflows
+- **Pattern:** Context Discipline (Pattern 7)
 
-4. **Confirm storage**
-   Show the learning ID and confirm it was saved.
+### CLAUDE.md & Memory
+- CLAUDE.md is persistent project memory. It loads every session.
+- Put: project structure, build commands, conventions, constraints, gotchas.
+- Don't put: entire file contents, obvious things, rapidly changing info.
+- For complex projects, split into AGENTS.md, SOUL.md, LEARNED.md.
+- **Docs:** https://code.claude.com/docs/settings
+- **Pattern:** Split Memory (Pattern 4)
 
-## Example
+### Modes
+- **Normal** — Claude asks before edits (default)
+- **Auto-Accept** — Claude edits without asking (trusted iteration)
+- **Plan** — Research first, then propose plan (complex tasks)
+- Use Plan mode when: >3 files, architecture decisions, multiple approaches, unclear requirements.
+- Toggle with `Shift+Tab`.
+- **Docs:** https://code.claude.com/docs/common-workflows
+- **Pattern:** 80/20 Review (Pattern 5)
+
+### CLI Shortcuts
+| Shortcut | Action |
+|----------|--------|
+| `Shift+Tab` | Cycle modes |
+| `Ctrl+L` | Clear screen |
+| `Ctrl+C` | Cancel generation |
+| `Ctrl+B` | Run task in background |
+| `Up/Down` | Prompt history |
+| `/compact` | Compact context |
+| `/context` | Check context usage |
+| `/clear` | Clear conversation |
+- **Docs:** https://code.claude.com/docs/cli-reference
+
+### Prompting
+Good prompts have four parts:
+1. **Scope** — What files/area to work in
+2. **Context** — Background info Claude needs
+3. **Constraints** — What NOT to do
+4. **Acceptance criteria** — How to know it's done
+
+Bad: "Add rate limiting"
+Good: "In src/auth/, add rate limiting to the login endpoint. We use Express with Redis. Don't change session middleware. Return 429 after 5 failed attempts per IP in 15 min."
+
+### Writing Rules
+Rules in CLAUDE.md prevent Claude from going off-track.
+- Good: "Always use snake_case for database columns"
+- Good: "Run pytest -x after any Python file change"
+- Bad: "Write good code"
+- Bad: "Be careful"
+- **Pattern:** Self-Correction Loop (Pattern 1)
+
+### Skills
+Skills are reusable commands defined in markdown with frontmatter. Create one when you repeat the same prompt pattern >3 times.
+- **Docs:** https://code.claude.com/docs/settings
+- **Pattern:** Learning Log (Pattern 8)
+
+### Subagents
+Subagents run in separate context windows for parallel work.
+- Use for: parallel exploration, background tasks, independent research.
+- Avoid for: single-file reads, tasks needing conversation context.
+- Press `Ctrl+B` to send tasks to background.
+- **Docs:** https://code.claude.com/docs/sub-agents
+- **Pattern:** Parallel Worktrees (Pattern 2)
+
+### Hooks
+Hooks run scripts on events to automate quality enforcement.
+- Types: PreToolUse, PostToolUse, SessionStart, SessionEnd, Stop, UserPromptSubmit
+- Pro-Workflow ships hooks for edit tracking, quality gates, and learning capture.
+- **Docs:** https://code.claude.com/docs/hooks
+
+### Security
+- Review permission requests carefully.
+- Don't auto-approve shell commands you don't understand.
+- Keep secrets out of CLAUDE.md.
+- Use `.gitignore` and `.claudeignore` for sensitive files.
+- **Docs:** https://code.claude.com/docs/security
+
+### MCP
+- Keep <10 MCPs enabled, <80 tools total.
+- Disable MCPs you're not actively using.
+- Each MCP adds context overhead.
+- **Docs:** https://code.claude.com/docs/mcp
+
+### Integration
+- **VS Code / JetBrains:** https://code.claude.com/docs/ide-integration
+- **GitHub Actions:** https://code.claude.com/docs/github-actions
+- **Troubleshooting:** https://code.claude.com/docs/troubleshooting
+
+## Learning Path
+
+**Beginner:** Sessions, CLI shortcuts, context management, modes
+**Intermediate:** CLAUDE.md, writing rules, prompting, skills
+**Advanced:** Subagents, hooks, MCP, GitHub Actions, Pro-Workflow patterns 1-8
+
+## Saving Learnings
+
+Capture a lesson from this session:
 
 ```
-Recent mistake: Edited wrong utils.ts file when there were multiple
-
-Category: Navigation
-Rule: Confirm full path when multiple files share a name
-Mistake: Edited src/utils.ts instead of lib/utils.ts
-Correction: User pointed out the file was in lib/, not src/
-
-Saved as learning #42. Use /search utils to find this later.
+Category: <category>
+Rule: <one-line description of the correct behavior>
+Mistake: <what went wrong>
+Correction: <how it was fixed>
 ```
 
-## Database Location
+### Categories
+- Navigation (file paths, finding code)
+- Editing (code changes, patterns)
+- Testing (test approaches)
+- Git (commits, branches)
+- Quality (lint, types, style)
+- Context (when to clarify)
+- Architecture (design decisions)
+- Performance (optimization)
+- Claude-Code (sessions, modes, CLAUDE.md, skills, subagents, hooks, MCP)
+- Prompting (scope, constraints, acceptance criteria)
+
+### Example
+
+```
+Category: Claude-Code
+Rule: Use plan mode before multi-file changes
+Mistake: Started editing 5 files without a plan, had to redo
+Correction: Enter plan mode first, get approval, then execute
+
+Saved as learning #42. Use /search plan to find this later.
+```
 
 Learnings are stored in `~/.pro-workflow/data.db` and persist across sessions.
 
@@ -53,4 +150,4 @@ Use `/list` to see all learnings.
 
 ---
 
-**Trigger:** Use when user says "remember this", "add to rules", "learn this", or after making a mistake that should be captured.
+**Trigger:** Use when user says "learn", "teach me", "best practices", "remember this", or after making a mistake.

--- a/commands/list.md
+++ b/commands/list.md
@@ -47,6 +47,8 @@ Available categories:
 - Context
 - Architecture
 - Performance
+- Claude-Code
+- Prompting
 
 ## Related Commands
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "contexts",
     "templates",
     "rules",
+    "references",
     "skills",
     "config.json",
     "README.md"

--- a/references/claude-code-resources.md
+++ b/references/claude-code-resources.md
@@ -1,0 +1,244 @@
+# Claude Code Best Practices
+
+Essential patterns for mastering Claude Code. Internalized from production use, referencing official documentation at https://code.claude.com/docs/ for deep dives.
+
+## Official Documentation
+
+**Source:** https://code.claude.com/docs/
+
+| Topic | URL | When to Reference |
+|-------|-----|-------------------|
+| Quickstart | https://code.claude.com/docs/quickstart | First-time setup, onboarding |
+| Common Workflows | https://code.claude.com/docs/common-workflows | Day-to-day patterns |
+| CLI Reference | https://code.claude.com/docs/cli-reference | Commands, flags, shortcuts |
+| Settings | https://code.claude.com/docs/settings | CLAUDE.md, config, preferences |
+| Sub-agents | https://code.claude.com/docs/sub-agents | Task delegation, parallel work |
+| MCP | https://code.claude.com/docs/mcp | External tool integration |
+| Hooks | https://code.claude.com/docs/hooks | Automation, quality gates |
+| Security | https://code.claude.com/docs/security | Permissions, sandboxing |
+| Troubleshooting | https://code.claude.com/docs/troubleshooting | Common issues |
+| GitHub Actions | https://code.claude.com/docs/github-actions | CI/CD automation |
+| IDE Integration | https://code.claude.com/docs/ide-integration | VS Code, JetBrains |
+
+## Sessions & Context
+
+Every Claude Code invocation is a session. Claude reads your project structure on start.
+
+**Key practices:**
+- Context window is finite (200k tokens). Use `/context` to check usage.
+- Use `/compact` at task boundaries — after planning, after completing a feature, when context >70%.
+- Don't compact mid-task. You lose important working context.
+- Summarize exploration results before moving to implementation.
+
+**Pro-Workflow pattern:** Context Discipline (Pattern 7)
+**Docs:** https://code.claude.com/docs/common-workflows
+
+## CLAUDE.md & Memory
+
+CLAUDE.md is persistent project memory that loads every session. It's the most important file for productivity.
+
+**What to put in CLAUDE.md:**
+- Project structure and architecture overview
+- Build/test/lint commands
+- Code conventions and style rules
+- Common gotchas specific to your project
+- Constraints Claude should respect
+
+**What NOT to put:**
+- Entire file contents (wastes context)
+- Obvious things any developer would know
+- Rapidly changing information
+
+**Pro-Workflow pattern:** Split Memory (Pattern 4), Self-Correction Loop (Pattern 1)
+**Docs:** https://code.claude.com/docs/settings
+
+## Modes
+
+Three modes for different work styles:
+
+| Mode | When | Behavior |
+|------|------|----------|
+| **Normal** | Default | Claude asks before edits |
+| **Auto-Accept** | Trusted iteration | Claude edits without asking |
+| **Plan** | Complex tasks | Research first, then propose plan |
+
+**When to use Plan mode:**
+- Task touches >3 files
+- Architecture decisions needed
+- Multiple valid approaches exist
+- Requirements are unclear
+
+**Toggle:** `Shift+Tab` cycles through modes.
+
+**Pro-Workflow pattern:** 80/20 Review (Pattern 5)
+**Docs:** https://code.claude.com/docs/common-workflows
+
+## CLI Navigation
+
+Essential shortcuts for speed:
+
+| Shortcut | Action |
+|----------|--------|
+| `Shift+Tab` | Cycle modes (Normal → Auto → Plan) |
+| `Ctrl+L` | Clear screen |
+| `Ctrl+C` | Cancel current generation |
+| `Ctrl+B` | Run current task in background |
+| `Up/Down` | Navigate prompt history |
+| `/compact` | Compact context |
+| `/context` | Check context usage |
+| `/clear` | Clear conversation |
+
+**Pro-Workflow pattern:** Context Discipline (Pattern 7)
+**Docs:** https://code.claude.com/docs/cli-reference
+
+## Prompting
+
+Good prompts have four parts:
+
+1. **Scope** — What files/area to work in
+2. **Context** — Background info Claude needs
+3. **Constraints** — What NOT to do, limits
+4. **Acceptance criteria** — How to know it's done
+
+**Example of a good prompt:**
+```
+In src/auth/, add rate limiting to the login endpoint.
+We use Express with Redis for sessions.
+Don't change the session middleware.
+It should return 429 after 5 failed attempts per IP in 15 minutes.
+```
+
+**Example of a bad prompt:**
+```
+Add rate limiting
+```
+
+**Pro-Workflow pattern:** 80/20 Review (Pattern 5)
+
+## Writing Rules & Constraints
+
+Rules in CLAUDE.md prevent Claude from going off-track. Be specific.
+
+**Good rules:**
+```
+- Always use snake_case for database columns
+- Never modify files in vendor/
+- Run `pytest -x` after any Python file change
+- Use TypeScript strict mode, no `any` types
+```
+
+**Bad rules:**
+```
+- Write good code
+- Follow best practices
+- Be careful
+```
+
+**Pro-Workflow pattern:** Self-Correction Loop (Pattern 1)
+
+## Skills & Automation
+
+Skills are reusable Claude Code commands defined in markdown with frontmatter.
+
+**When to create a skill:**
+- You repeat the same prompt pattern >3 times
+- A workflow has a consistent structure
+- You want to share a pattern with your team
+
+**Skill structure:**
+```markdown
+---
+name: my-skill
+description: What this skill does
+tools: Read, Grep, Edit
+---
+
+Instructions for Claude when this skill is invoked.
+```
+
+**Pro-Workflow pattern:** Learning Log (Pattern 8)
+**Docs:** https://code.claude.com/docs/settings
+
+## Subagents & Parallelism
+
+Subagents run in separate context windows. Use them for parallel work.
+
+**When to use subagents:**
+- Parallel file exploration
+- Background long-running operations
+- Independent research tasks
+
+**When NOT to use subagents:**
+- Simple single-file reads
+- Tasks needing conversation context
+- Sequential dependent operations
+
+**Background execution:** Press `Ctrl+B` to send a task to background while you continue working.
+
+**Pro-Workflow pattern:** Parallel Worktrees (Pattern 2)
+**Docs:** https://code.claude.com/docs/sub-agents
+
+## Hooks
+
+Hooks automate quality enforcement. They run scripts on specific events.
+
+**Hook types:**
+- `PreToolUse` — Before edits, commits, pushes
+- `PostToolUse` — After edits, test runs
+- `SessionStart` — Load patterns, check state
+- `SessionEnd` — Capture learnings, check uncommitted
+- `Stop` — After each response
+- `UserPromptSubmit` — Before processing user input
+
+**Pro-Workflow pattern:** All hooks in `hooks/hooks.json`
+**Docs:** https://code.claude.com/docs/hooks
+
+## Security & Permissions
+
+Claude Code has a permission model. Understand it before handling sensitive data.
+
+**Key principles:**
+- Review permission requests carefully
+- Don't auto-approve shell commands you don't understand
+- Keep secrets out of CLAUDE.md
+- Use `.gitignore` and `.claudeignore` for sensitive files
+
+**Docs:** https://code.claude.com/docs/security
+
+## MCP (Model Context Protocol)
+
+MCP connects Claude to external tools and data sources.
+
+**Guidelines:**
+- Keep <10 MCPs enabled
+- Keep total tools <80
+- Disable MCPs you're not actively using
+- Each MCP adds context overhead
+
+**Docs:** https://code.claude.com/docs/mcp
+
+## Integration
+
+| Platform | Docs |
+|----------|------|
+| VS Code | https://code.claude.com/docs/ide-integration |
+| JetBrains | https://code.claude.com/docs/ide-integration |
+| GitHub Actions | https://code.claude.com/docs/github-actions |
+
+## How to Use These Practices
+
+### With /learn-rule
+When you discover a Claude Code best practice:
+```
+[LEARN] Claude-Code: <the practice>
+```
+
+### With /learn
+Save to database with `Claude-Code` category for searchability.
+
+### Learning Path
+1. **Start** — Read the quickstart, learn CLI shortcuts, understand context limits
+2. **Build** — Write a good CLAUDE.md, learn modes, improve your prompts
+3. **Scale** — Create skills, use subagents, set up hooks
+4. **Optimize** — Layer Pro-Workflow patterns 1-8 for production use
+5. **Reference** — Official docs for deep dives on any topic

--- a/rules/core-rules.md
+++ b/rules/core-rules.md
@@ -36,3 +36,16 @@ Universal rules for any project. Add to CLAUDE.md or use as reference.
 - Sonnet for features
 - Opus for architecture
 - Opus+Thinking for hard bugs
+
+## Claude Code Mastery
+Docs: https://code.claude.com/docs/
+- Use plan mode for multi-file changes
+- Write CLAUDE.md with structure, conventions, rules
+- Manage context: /compact at task boundaries, /context to check usage
+- Prompts need scope + context + constraints + acceptance criteria
+- Build skills for repeated workflows (>3 repetitions)
+- Delegate to subagents for parallel exploration
+- Keep <10 MCPs, <80 tools
+- Use hooks for automated quality gates
+- Review security model before handling sensitive data
+- See references/claude-code-resources.md for full guide

--- a/skills/pro-workflow/SKILL.md
+++ b/skills/pro-workflow/SKILL.md
@@ -241,6 +241,41 @@ Append to .claude/learning-log.md
 
 ---
 
+## Learn Claude Code
+
+**Master Claude Code through built-in best practices and official documentation.**
+
+Pro-workflow teaches Claude Code concepts directly and links to official docs at **https://code.claude.com/docs/** for deep dives.
+
+### What You'll Learn
+
+| Topic | Pro-Workflow Pattern | Official Docs |
+|-------|---------------------|---------------|
+| Sessions & context management | Pattern 7: Context Discipline | Common Workflows |
+| Modes (Plan/Normal/Auto) | Pattern 5: 80/20 Review | Common Workflows |
+| CLAUDE.md & project memory | Pattern 4: Split Memory | Settings |
+| Writing rules & constraints | Pattern 1: Self-Correction Loop | Settings |
+| Effective prompting | Pattern 5: 80/20 Review | — |
+| Skills & automation | Pattern 8: Learning Log | Settings |
+| Subagents & parallelism | Pattern 2: Parallel Worktrees | Sub-agents |
+| Hooks & quality gates | All hooks in hooks.json | Hooks |
+| Security & permissions | — | Security |
+| MCP configuration | Pattern 7: Context Discipline | MCP |
+
+### Learning Path
+
+1. **Start** — CLI shortcuts, context management, modes
+2. **Build** — CLAUDE.md, writing rules, prompting, skills
+3. **Scale** — Subagents, hooks, MCP, GitHub Actions
+4. **Optimize** — Pro-Workflow patterns 1-8 for production use
+5. **Reference** — Official docs for deep dives on any topic
+
+### Use /learn
+
+Run `/learn` for a topic-by-topic guide with practices and official doc links.
+
+---
+
 ## Quick Setup
 
 ### Minimal
@@ -374,6 +409,9 @@ See `mcp-config.example.json` for setup.
 | `/wrap-up` | End-of-session ritual |
 | `/learn-rule` | Extract correction to memory |
 | `/parallel` | Worktree setup guide |
+| `/learn` | Claude Code best practices & save learnings |
+| `/search` | Search learnings by keyword |
+| `/list` | List all stored learnings |
 
 ---
 


### PR DESCRIPTION
## Summary
- Enhanced `/learn` command to teach Claude Code best practices directly, linking to official docs at https://code.claude.com/docs/ for deep dives
- Added `references/claude-code-resources.md` with comprehensive best practices guide covering sessions, context, modes, CLAUDE.md, prompting, rules, skills, subagents, hooks, security, MCP, and integration
- Added `Claude-Code` and `Prompting` categories across all learning commands (`learn-rule`, `learn`, `list`)
- Added "Claude Code Mastery" section to `core-rules.md` and "Learn Claude Code" section to `SKILL.md`

## Test plan
- [ ] Run `/pro-workflow:learn` and verify best practices guide displays
- [ ] Run `/pro-workflow:learn-rule` and verify new categories (Claude-Code, Prompting) are listed
- [ ] Run `/pro-workflow:list` and verify new categories appear
- [ ] Verify all docs links point to https://code.claude.com/docs/ (no external repo references)
- [ ] Verify `references/claude-code-resources.md` is included in npm package (`npm pack --dry-run`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded comprehensive documentation covering Claude Code best practices, memory management, and workflow optimization.
  * Added detailed reference guides for learning and search capabilities.

* **New Features**
  * New `/learn` command for capturing and organizing Claude Code best practices.
  * New `/search` command for keyword-based searching of learnings.
  * Enhanced `/list` command with expanded category support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->