### PR TITLE
fix: add DB write path for /learn save command

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -65,6 +65,16 @@
           }
         ],
         "description": "Periodic wrap-up reminder and learning prompt"
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/learn-capture.js\""
+          }
+        ],
+        "description": "Auto-capture [LEARN] blocks from responses into database"
       }
     ],
     "SessionStart": [

--- a/scripts/learn-capture.js
+++ b/scripts/learn-capture.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+function getStore() {
+  const distPath = path.join(__dirname, '..', 'dist', 'db', 'store.js');
+  if (fs.existsSync(distPath)) {
+    const mod = require(distPath);
+    if (typeof mod.createStore === 'function') {
+      return mod.createStore();
+    }
+  }
+  return null;
+}
+
+async function main() {
+  let data = '';
+  process.stdin.on('data', chunk => { data += chunk; });
+  process.stdin.on('end', () => {
+    try {
+      const input = JSON.parse(data);
+      const response = input.assistant_response || '';
+      if (!response) {
+        console.log(data);
+        return;
+      }
+
+      const regex = /\[LEARN\]\s*([\w][\w\s-]*?)\s*:\s*(.+?)(?:\nMistake:\s*(.+?))?(?:\nCorrection:\s*(.+?))?(?=\n\[LEARN\]|\n\n|$)/gim;
+
+      let match;
+      let store = null;
+      let count = 0;
+      let lastIndex = -1;
+
+      while ((match = regex.exec(response)) !== null) {
+        if (regex.lastIndex === lastIndex) break;
+        lastIndex = regex.lastIndex;
+
+        if (!store) store = getStore();
+        if (!store) break;
+
+        const projectDir = process.env.CLAUDE_PROJECT_DIR || '';
+        store.addLearning({
+          project: projectDir ? path.basename(projectDir) : null,
+          category: match[1].trim(),
+          rule: match[2].trim(),
+          mistake: match[3]?.trim() || null,
+          correction: match[4]?.trim() || null,
+        });
+        count++;
+      }
+
+      if (count > 0) {
+        console.error(`[ProWorkflow] Auto-saved ${count} learning(s) to database`);
+      }
+      if (store) store.close();
+    } catch (err) {
+      console.error(`[ProWorkflow] Learn-capture error: ${err.message}`);
+    }
+    console.log(data);
+  });
+}
+
+main().catch(() => process.exit(0));


### PR DESCRIPTION
## Summary

- **Updated `commands/learn.md`** with explicit step-by-step instructions for saving learnings to the SQLite database (sqlite3 INSERT and store API examples)
- **Added `scripts/learn-capture.js`** Stop hook that auto-captures `[LEARN]` blocks from Claude's responses and writes them to the DB via the existing `store.addLearning()` API
- **Registered the hook** in `hooks/hooks.json` as a Stop hook

## Details

The `/learn save` command described the learning format but never told Claude how to actually persist to `~/.pro-workflow/data.db`. This meant the learnings table stayed empty and `/search`, `/replay`, `/list` returned nothing.

### Dual fix approach:
1. **Explicit instructions** in learn.md — Claude now has exact SQL/JS commands to save learnings (matching how replay.md provides exact SQL for reads)
2. **Auto-capture hook** — a Stop hook parses `[LEARN]` blocks from responses and saves them transparently, so learnings persist even without Claude running a separate DB command

### Safeguards in learn-capture.js:
- Infinite loop guard for regex exec
- Store API validation before calling
- Error logging to stderr (not silent)
- Early return on empty response
- Proper store cleanup

Closes #13

## Test plan
- [ ] Run `/learn save` and verify learning is inserted into `~/.pro-workflow/data.db`
- [ ] Include `[LEARN]` block in a response and verify Stop hook auto-captures it
- [ ] Run `/search` after saving and verify the learning appears
- [ ] Verify existing Stop hook (session-check.js) still works alongside learn-capture.js