### PR TITLE
feat: improve skill descriptions and content across all 9 skills

### DIFF
--- a/skills/deslop/SKILL.md
+++ b/skills/deslop/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deslop
-description: Remove AI-generated code slop, unnecessary comments, and over-engineering from the current branch diff. Use after completing changes and before committing.
+description: Remove AI-generated code slop, unnecessary comments, and over-engineering from the current branch diff. Cleans up boilerplate, simplifies abstractions, and strips defensive code. Use when cleaning up code, simplifying, removing boilerplate, or before committing.
 ---
 
 # Remove AI Code Slop
@@ -18,6 +18,15 @@ git fetch origin main
 git diff origin/main...HEAD --stat
 git diff origin/main...HEAD
 ```
+
+## Workflow
+
+1. Run diff commands to see all changes on the branch.
+2. Identify slop patterns from the focus areas below.
+3. Apply minimal, focused edits to remove slop.
+4. Re-run `git diff origin/main...HEAD` to verify only slop was removed.
+5. Run tests or type-check to confirm behaviour unchanged: `npm test -- --changed --passWithNoTests 2>&1 | tail -10`
+6. Summarise what was cleaned.
 
 ## Focus Areas
 

--- a/skills/insights/SKILL.md
+++ b/skills/insights/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: insights
-description: Show session analytics, learning patterns, correction trends, heatmaps, and productivity metrics. Use when wanting to understand your coding patterns over time.
+description: Show session analytics, learning patterns, correction trends, heatmaps, and productivity metrics. Computes stats from project memory and session history. Use when asking for stats, statistics, progress, how am I doing, coding history, or dashboard.
 ---
 
 # Session Insights
@@ -10,6 +10,22 @@ Surface patterns from learnings and session history.
 ## Trigger
 
 Use when asking "show stats", "how am I doing", "analytics", "insights", "heatmap", or "correction rate".
+
+## Data Sources
+
+Gather data from these locations before computing metrics:
+
+```bash
+# Session history and learnings
+cat .claude/LEARNED.md 2>/dev/null || cat CLAUDE.md | grep -A999 "LEARNED"
+cat .claude/learning-log.md 2>/dev/null
+
+# Session activity
+git log --oneline --since="today" --author="$(git config user.name)"
+git diff --stat
+```
+
+A **correction** is any instance where the user redirected, fixed, or overrode agent output during a session. Count `[LEARN]` entries and explicit correction markers in session history.
 
 ## What It Shows
 

--- a/skills/learn-rule/SKILL.md
+++ b/skills/learn-rule/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: learn-rule
-description: Capture a correction or lesson as a persistent learning rule with category, mistake, and correction. Use after mistakes or when the user says "remember this".
+description: Capture a correction or lesson as a persistent learning rule with category, mistake, and correction. Stores, categorises, and retrieves rules for future sessions. Use after mistakes or when the user says "remember this", "don't forget", "note this", or "learn from this".
 ---
 
 # Learn Rule

--- a/skills/parallel-worktrees/SKILL.md
+++ b/skills/parallel-worktrees/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: parallel-worktrees
-description: Set up parallel coding sessions using git worktrees for zero dead time. Use when blocked on tests, builds, or wanting to explore multiple approaches simultaneously.
+description: Create and manage git worktrees for parallel coding sessions with zero dead time. Use when blocked on tests, builds, wanting to work on multiple branches, context switching, or exploring multiple approaches simultaneously.
 ---
 
 # Parallel Worktrees
@@ -78,6 +78,7 @@ Each worktree runs its own AI session independently.
 ## Guardrails
 
 - Each worktree is a full working copy — changes are isolated.
+- Before removing a worktree, verify changes are committed: `git -C ../project-feat status`
 - Don't forget to clean up worktrees when done (`git worktree prune`).
 - Avoid editing the same files in multiple worktrees simultaneously.
 

--- a/skills/pro-workflow/SKILL.md
+++ b/skills/pro-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pro-workflow
-description: Battle-tested AI coding workflows from power users. Self-correcting memory, parallel worktrees, wrap-up rituals, and the 80/20 AI coding ratio. Works with Claude Code, Cursor, and other agents.
+description: Implement self-correcting memory, parallel worktrees, wrap-up rituals, and review checkpoints for AI coding sessions. Configures CLAUDE.md rules, quality gates, and context management. Use when setting up AI coding best practices, optimising agent workflows, or asking about Claude Code or Cursor productivity patterns.
 ---
 
 # Pro Workflow
@@ -266,39 +266,7 @@ Append to .claude/learning-log.md
 
 ## Learn Claude Code
 
-**Master Claude Code through built-in best practices and official documentation.**
-
-Pro-workflow teaches Claude Code concepts directly and links to official docs at **https://code.claude.com/docs/** for deep dives.
-
-### What You'll Learn
-
-| Topic | Pro-Workflow Pattern | Official Docs |
-|-------|---------------------|---------------|
-| Sessions & context management | Pattern 7: Context Discipline | Common Workflows |
-| Modes (Plan/Normal/Auto/Delegate) | Pattern 5: 80/20 Review | Common Workflows |
-| CLAUDE.md & project memory | Pattern 4: Split Memory | Settings |
-| Writing rules & constraints | Pattern 1: Self-Correction Loop | Settings |
-| Effective prompting | Pattern 5: 80/20 Review | — |
-| Skills & automation | Pattern 8: Learning Log | Settings |
-| Custom subagents | Pattern 2: Parallel Worktrees | Sub-agents |
-| Agent teams | Pattern 2: Parallel Worktrees | Agent Teams |
-| Hooks & quality gates | All hooks in hooks.json | Hooks |
-| Context compaction | Pattern 7: Context Discipline | Common Workflows |
-| Adaptive thinking | Pattern 6: Model Selection | — |
-| Security & permissions | — | Security |
-| MCP configuration | Pattern 7: Context Discipline | MCP |
-
-### Learning Path
-
-1. **Start** — CLI shortcuts, context management, modes
-2. **Build** — CLAUDE.md, writing rules, prompting, skills
-3. **Scale** — Custom subagents, agent teams, hooks, MCP, GitHub Actions
-4. **Optimize** — Pro-Workflow patterns 1-8, adaptive thinking, context compaction
-5. **Reference** — Official docs for deep dives on any topic
-
-### Use /learn
-
-Run `/learn` for a topic-by-topic guide with practices and official doc links.
+Run `/learn` for a topic-by-topic guide covering sessions, context, CLAUDE.md, subagents, hooks, and more. Official docs: **https://code.claude.com/docs/**
 
 ---
 
@@ -464,15 +432,3 @@ These slash commands are available when using pro-workflow as a Claude Code plug
 | `/commit` | Smart commit with quality gates | `smart-commit` skill |
 | `/insights` | Session analytics and patterns | `insights` skill |
 
----
-
-## Philosophy
-
-1. **Compound improvements** - Small corrections → big gains
-2. **Trust but verify** - Let AI work, review at checkpoints
-3. **Zero dead time** - Parallel sessions
-4. **Memory is precious** - Yours and the AI's
-
----
-
-*From AI coding power users and real production use.*

--- a/skills/replay-learnings/SKILL.md
+++ b/skills/replay-learnings/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: replay-learnings
-description: Surface past learnings relevant to the current task before starting work. Searches correction history and patterns. Use when starting a task or saying "what do I know about".
+description: Surface past learnings relevant to the current task before starting work. Searches correction history, recalls past mistakes, and applies prior patterns. Use when starting a task, saying "what do I know about", "previous mistakes", "lessons learned", or "remind me about".
 ---
 
 # Replay Learnings
@@ -13,8 +13,13 @@ Use when starting a new task, saying "what do I know about", "before I start", "
 
 ## Workflow
 
-1. Extract keywords from the task description.
-2. Search learnings/memory for matching patterns (corrections, rules, past mistakes).
+1. Extract keywords from the task description (e.g. "auth refactor" → `auth`, `middleware`, `refactor`).
+2. Search learnings/memory for matching patterns:
+   ```bash
+   grep -i "auth\|middleware" .claude/LEARNED.md 2>/dev/null
+   grep -i "auth\|middleware" .claude/learning-log.md 2>/dev/null
+   grep -A2 "\[LEARN\]" CLAUDE.md | grep -i "auth\|middleware"
+   ```
 3. Check session history for similar work — what was the correction rate?
 4. Surface the top learnings ranked by relevance.
 5. If no learnings found, suggest starting with the scout agent to explore first.

--- a/skills/session-handoff/SKILL.md
+++ b/skills/session-handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: session-handoff
-description: Generate a structured handoff document designed for the next session to consume immediately and continue where you left off. Use when ending a session.
+description: Generate a structured handoff document capturing current progress, open tasks, key decisions, and context needed to resume work. Use when ending a session, saying "continue later", "save progress", "session summary", or "pick up where I left off".
 ---
 
 # Session Handoff

--- a/skills/smart-commit/SKILL.md
+++ b/skills/smart-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: smart-commit
-description: Run quality gates, review staged changes for issues, and create a well-crafted conventional commit. Use when ready to commit after making changes.
+description: Run quality gates, review staged changes for issues, and create a well-crafted conventional commit. Use when saying "commit", "git commit", "save my changes", or ready to commit after making changes.
 ---
 
 # Smart Commit

--- a/skills/wrap-up/SKILL.md
+++ b/skills/wrap-up/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wrap-up
-description: End-of-session ritual that audits changes, runs quality checks, captures learnings, and produces a session summary. Use when ending a coding session.
+description: End-of-session ritual that audits changes, runs quality checks, captures learnings, and produces a session summary. Use when saying "wrap up", "done for the day", "finish coding", or ending a coding session.
 ---
 
 # Wrap-Up Ritual


### PR DESCRIPTION
Hullo Rohit 👋

Thanks for engaging on the product hunt launch, and for publishing your skills in the Tessl registry! Nice work! I ran all nine skills through `tessl skill review` at work and found some targeted improvements. Here's the before/after:

<img width="1312" height="1214" alt="score_card" src="https://github.com/user-attachments/assets/e59f9ff1-6519-453b-b968-8dd866e91dc1" />

The pro-workflow one in particular saw more significant improvements.

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| pro-workflow | 55% | 93% | +38% |
| replay-learnings | 80% | 100% | +20% |
| deslop | 86% | 100% | +14% |
| learn-rule | 88% | 100% | +12% |
| insights | 75% | 86% | +11% |
| parallel-worktrees | 81% | 89% | +8% |
| smart-commit | 93% | 100% | +7% |
| wrap-up | 93% | 100% | +7% |
| session-handoff | 88% | 94% | +6% |

<details><summary>Summary of changes</summary>

- **pro-workflow**: Added `Use when...` clause with concrete trigger terms (AI coding best practices, agent workflows, Claude Code/Cursor productivity patterns). Replaced abstract marketing language with specific actions. Condensed Learn Claude Code section from 35 lines to 3 — the `/learn` command and docs link covers it. Removed Philosophy section (principles are implicit in the patterns). Net reduction of ~44 lines.
- **deslop**: Added trigger terms (cleaning up code, simplifying, removing boilerplate). Added explicit 6-step workflow with validation checkpoint — re-run diff to verify only slop removed, run tests to confirm behaviour unchanged.
- **insights**: Added trigger terms (stats, statistics, progress, how am I doing, dashboard). Added Data Sources section with concrete bash commands for accessing session history and project memory, plus definition of what constitutes a "correction".
- **learn-rule**: Expanded description with additional actions (stores, categorises, retrieves) and trigger terms (don't forget, note this, learn from this).
- **replay-learnings**: Added trigger terms (previous mistakes, lessons learned, remind me about). Added concrete grep commands showing how to search learnings/memory files.
- **parallel-worktrees**: Added trigger terms (multiple branches, context switching). Added validation checkpoint in guardrails — verify changes committed before worktree removal.
- **session-handoff**: Expanded description with concrete actions (captures progress, open tasks, key decisions, context to resume). Added trigger terms (continue later, save progress, session summary, pick up where I left off).
- **smart-commit**: Added trigger terms (git commit, save my changes).
- **wrap-up**: Added trigger terms (wrap up, done for the day, finish coding).

</details>

Thanks again 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced skill descriptions and trigger phrases across multiple skills for clearer activation patterns, including deslop, learn-rule, parallel-worktrees, pro-workflow, replay-learnings, session-handoff, smart-commit, and wrap-up.
  * Expanded insights skill documentation with data source clarification and correction counting definitions.
  * Added safety guardrail for parallel worktree removal verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->