### PR TITLE
fix: rebrand visuals to Anthropic colors, update infographic to v2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/rohitg00/pro-workflow/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/pro-workflow?style=for-the-badge&logo=github&color=6366f1&labelColor=1e1e2e" alt="Stars"/></a>
-  <a href="https://www.npmjs.com/package/pro-workflow"><img src="https://img.shields.io/npm/v/pro-workflow?style=for-the-badge&logo=npm&color=a78bfa&labelColor=1e1e2e" alt="npm"/></a>
+  <a href="https://github.com/rohitg00/pro-workflow/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/pro-workflow?style=for-the-badge&logo=github&color=D97757&labelColor=1e1e2e" alt="Stars"/></a>
+  <a href="https://www.npmjs.com/package/pro-workflow"><img src="https://img.shields.io/npm/v/pro-workflow?style=for-the-badge&logo=npm&color=E8926F&labelColor=1e1e2e" alt="npm"/></a>
   <a href="https://github.com/rohitg00/pro-workflow/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-22c55e?style=for-the-badge&labelColor=1e1e2e" alt="License"/></a>
   <a href="https://agenstskills.com"><img src="https://img.shields.io/badge/SkillKit-32%2B%20agents-f59e0b?style=for-the-badge&labelColor=1e1e2e" alt="SkillKit"/></a>
 </p>
@@ -232,7 +232,7 @@ graph LR
 
     C -->|Needs permission| K[PermissionRequest]
 
-    style A fill:#6366f1,color:#fff,stroke:none
+    style A fill:#D97757,color:#fff,stroke:none
     style H fill:#ef4444,color:#fff,stroke:none
     style D fill:#f59e0b,color:#000,stroke:none
     style E fill:#22c55e,color:#fff,stroke:none
@@ -289,8 +289,8 @@ graph TD
     SK --> WS[Windsurf]
     SK --> MORE[27+ more]
 
-    style PW fill:#6366f1,color:#fff,stroke:none
-    style CC fill:#a78bfa,color:#fff,stroke:none
+    style PW fill:#D97757,color:#fff,stroke:none
+    style CC fill:#E8926F,color:#fff,stroke:none
     style CU fill:#f59e0b,color:#000,stroke:none
     style SK fill:#22c55e,color:#fff,stroke:none
 ```
@@ -398,7 +398,7 @@ cp -r /tmp/pw/templates/split-claude-md/* ./.claude/
   <br/>
   <b>If you find this useful, star the repo to help others discover it.</b>
   <br/><br/>
-  <a href="https://github.com/rohitg00/pro-workflow/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/pro-workflow?style=for-the-badge&logo=github&color=6366f1&labelColor=1e1e2e" alt="Stars"/></a>
+  <a href="https://github.com/rohitg00/pro-workflow/stargazers"><img src="https://img.shields.io/github/stars/rohitg00/pro-workflow?style=for-the-badge&logo=github&color=D97757&labelColor=1e1e2e" alt="Stars"/></a>
   <br/><br/>
   <a href="https://agenstskills.com">SkillKit Marketplace</a> &bull;
   <a href="https://github.com/rohitg00/pro-workflow/issues">Report Issues</a> &bull;

--- a/assets/architecture.svg
+++ b/assets/architecture.svg
@@ -1,15 +1,15 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 500" width="900" height="500">
   <defs>
     <linearGradient id="bg2" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1a1a3e;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#191A23;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1E1F2E;stop-opacity:1" />
     </linearGradient>
     <filter id="glow2">
       <feGaussianBlur stdDeviation="2" result="blur"/>
       <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
     </filter>
     <marker id="arrow" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
-      <polygon points="0 0, 10 3.5, 0 7" fill="#6366f1"/>
+      <polygon points="0 0, 10 3.5, 0 7" fill="#D97757"/>
     </marker>
     <marker id="arrowGreen" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
       <polygon points="0 0, 10 3.5, 0 7" fill="#22c55e"/>
@@ -22,51 +22,51 @@
   <text x="450" y="60" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#64748b">Command &gt; Agent &gt; Skill Orchestration</text>
 
   <!-- Layer 1: Commands -->
-  <rect x="50" y="80" width="800" height="80" rx="10" fill="none" stroke="#6366f1" stroke-width="1" stroke-dasharray="4,4" opacity="0.5"/>
-  <text x="70" y="100" font-family="'SF Mono', monospace" font-size="11" fill="#6366f1" font-weight="600">COMMANDS (User Entry Points)</text>
+  <rect x="50" y="80" width="800" height="80" rx="10" fill="none" stroke="#D97757" stroke-width="1" stroke-dasharray="4,4" opacity="0.5"/>
+  <text x="70" y="100" font-family="'SF Mono', monospace" font-size="11" fill="#D97757" font-weight="600">COMMANDS (User Entry Points)</text>
 
-  <rect x="70" y="110" width="110" height="36" rx="8" fill="#1e1e3f" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="125" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">/develop</text>
+  <rect x="70" y="110" width="110" height="36" rx="8" fill="#252636" stroke="#D97757" stroke-width="1.5"/>
+  <text x="125" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">/develop</text>
 
-  <rect x="200" y="110" width="110" height="36" rx="8" fill="#1e1e3f" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="255" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">/commit</text>
+  <rect x="200" y="110" width="110" height="36" rx="8" fill="#252636" stroke="#D97757" stroke-width="1.5"/>
+  <text x="255" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">/commit</text>
 
-  <rect x="330" y="110" width="110" height="36" rx="8" fill="#1e1e3f" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="385" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">/wrap-up</text>
+  <rect x="330" y="110" width="110" height="36" rx="8" fill="#252636" stroke="#D97757" stroke-width="1.5"/>
+  <text x="385" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">/wrap-up</text>
 
-  <rect x="460" y="110" width="110" height="36" rx="8" fill="#1e1e3f" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="515" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">/doctor</text>
+  <rect x="460" y="110" width="110" height="36" rx="8" fill="#252636" stroke="#D97757" stroke-width="1.5"/>
+  <text x="515" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">/doctor</text>
 
-  <rect x="590" y="110" width="110" height="36" rx="8" fill="#1e1e3f" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="645" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">/insights</text>
+  <rect x="590" y="110" width="110" height="36" rx="8" fill="#252636" stroke="#D97757" stroke-width="1.5"/>
+  <text x="645" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">/insights</text>
 
-  <rect x="720" y="110" width="110" height="36" rx="8" fill="#1e1e3f" stroke="#6366f1" stroke-width="1.5"/>
-  <text x="775" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">/replay</text>
+  <rect x="720" y="110" width="110" height="36" rx="8" fill="#252636" stroke="#D97757" stroke-width="1.5"/>
+  <text x="775" y="133" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">/replay</text>
 
   <!-- Arrow down -->
-  <line x1="125" y1="146" x2="125" y2="195" stroke="#6366f1" stroke-width="2" marker-end="url(#arrow)"/>
+  <line x1="125" y1="146" x2="125" y2="195" stroke="#D97757" stroke-width="2" marker-end="url(#arrow)"/>
 
   <!-- Layer 2: Agents -->
   <rect x="50" y="200" width="800" height="100" rx="10" fill="none" stroke="#f59e0b" stroke-width="1" stroke-dasharray="4,4" opacity="0.5"/>
   <text x="70" y="220" font-family="'SF Mono', monospace" font-size="11" fill="#f59e0b" font-weight="600">AGENTS (Execution Layer)</text>
 
-  <rect x="70" y="235" width="130" height="50" rx="8" fill="#1e1e3f" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="70" y="235" width="130" height="50" rx="8" fill="#252636" stroke="#f59e0b" stroke-width="1.5"/>
   <text x="135" y="255" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#fbbf24" font-weight="600">orchestrator</text>
   <text x="135" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Research &gt; Plan &gt; Build</text>
 
-  <rect x="220" y="235" width="120" height="50" rx="8" fill="#1e1e3f" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="220" y="235" width="120" height="50" rx="8" fill="#252636" stroke="#f59e0b" stroke-width="1.5"/>
   <text x="280" y="255" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#fbbf24" font-weight="600">reviewer</text>
   <text x="280" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Security + Quality</text>
 
-  <rect x="360" y="235" width="120" height="50" rx="8" fill="#1e1e3f" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="360" y="235" width="120" height="50" rx="8" fill="#252636" stroke="#f59e0b" stroke-width="1.5"/>
   <text x="420" y="255" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#fbbf24" font-weight="600">planner</text>
   <text x="420" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Read-Only Plans</text>
 
-  <rect x="500" y="235" width="120" height="50" rx="8" fill="#1e1e3f" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="500" y="235" width="120" height="50" rx="8" fill="#252636" stroke="#f59e0b" stroke-width="1.5"/>
   <text x="560" y="255" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#fbbf24" font-weight="600">scout</text>
   <text x="560" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Background Explore</text>
 
-  <rect x="640" y="235" width="120" height="50" rx="8" fill="#1e1e3f" stroke="#f59e0b" stroke-width="1.5"/>
+  <rect x="640" y="235" width="120" height="50" rx="8" fill="#252636" stroke="#f59e0b" stroke-width="1.5"/>
   <text x="700" y="255" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#fbbf24" font-weight="600">debugger</text>
   <text x="700" y="272" text-anchor="middle" font-family="system-ui, sans-serif" font-size="9" fill="#64748b">Root Cause Analysis</text>
 
@@ -77,20 +77,20 @@
   <rect x="50" y="330" width="530" height="80" rx="10" fill="none" stroke="#22c55e" stroke-width="1" stroke-dasharray="4,4" opacity="0.5"/>
   <text x="70" y="350" font-family="'SF Mono', monospace" font-size="11" fill="#22c55e" font-weight="600">SKILLS (Domain Knowledge)</text>
 
-  <rect x="70" y="360" width="95" height="36" rx="8" fill="#1e1e3f" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="117" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#4ade80">pro-workflow</text>
+  <rect x="70" y="360" width="95" height="36" rx="8" fill="#252636" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="117" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#2DD4A8">pro-workflow</text>
 
-  <rect x="175" y="360" width="105" height="36" rx="8" fill="#1e1e3f" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="227" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#4ade80">smart-commit</text>
+  <rect x="175" y="360" width="105" height="36" rx="8" fill="#252636" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="227" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#2DD4A8">smart-commit</text>
 
-  <rect x="290" y="360" width="85" height="36" rx="8" fill="#1e1e3f" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="332" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#4ade80">wrap-up</text>
+  <rect x="290" y="360" width="85" height="36" rx="8" fill="#252636" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="332" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#2DD4A8">wrap-up</text>
 
-  <rect x="385" y="360" width="85" height="36" rx="8" fill="#1e1e3f" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="427" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#4ade80">orchestrate</text>
+  <rect x="385" y="360" width="85" height="36" rx="8" fill="#252636" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="427" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#2DD4A8">orchestrate</text>
 
-  <rect x="480" y="360" width="85" height="36" rx="8" fill="#1e1e3f" stroke="#22c55e" stroke-width="1.5"/>
-  <text x="522" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#4ade80">+6 more</text>
+  <rect x="480" y="360" width="85" height="36" rx="8" fill="#252636" stroke="#22c55e" stroke-width="1.5"/>
+  <text x="522" y="383" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#2DD4A8">+6 more</text>
 
   <!-- Layer 4: Hooks -->
   <rect x="610" y="330" width="240" height="80" rx="10" fill="none" stroke="#ef4444" stroke-width="1" stroke-dasharray="4,4" opacity="0.5"/>
@@ -101,7 +101,7 @@
   <text x="630" y="400" font-family="'SF Mono', monospace" font-size="10" fill="#64748b">TaskCompleted +12 more</text>
 
   <!-- Bottom: Cross-Agent -->
-  <rect x="50" y="430" width="800" height="50" rx="10" fill="#1e1e3f" stroke="#64748b" stroke-width="1"/>
+  <rect x="50" y="430" width="800" height="50" rx="10" fill="#252636" stroke="#64748b" stroke-width="1"/>
   <text x="450" y="455" text-anchor="middle" font-family="system-ui, sans-serif" font-size="13" fill="#94a3b8">Works with: </text>
-  <text x="450" y="470" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">Claude Code  |  Cursor  |  Codex  |  Gemini CLI  |  32+ agents via SkillKit</text>
+  <text x="450" y="470" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">Claude Code  |  Cursor  |  Codex  |  Gemini CLI  |  32+ agents via SkillKit</text>
 </svg>

--- a/assets/banner.svg
+++ b/assets/banner.svg
@@ -1,18 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 300" width="1200" height="300">
   <defs>
     <linearGradient id="bgGrad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#1a1a3e;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#0f0f23;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#191A23;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#1E1F2E;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#191A23;stop-opacity:1" />
     </linearGradient>
     <linearGradient id="accentGrad" x1="0%" y1="0%" x2="100%" y2="0%">
-      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
-      <stop offset="50%" style="stop-color:#a78bfa;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#6366f1;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#D97757;stop-opacity:1" />
+      <stop offset="50%" style="stop-color:#E8926F;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#D97757;stop-opacity:1" />
     </linearGradient>
     <linearGradient id="glowGrad" x1="0%" y1="0%" x2="0%" y2="100%">
-      <stop offset="0%" style="stop-color:#a78bfa;stop-opacity:0.3" />
-      <stop offset="100%" style="stop-color:#a78bfa;stop-opacity:0" />
+      <stop offset="0%" style="stop-color:#E8926F;stop-opacity:0.3" />
+      <stop offset="100%" style="stop-color:#E8926F;stop-opacity:0" />
     </linearGradient>
     <filter id="glow">
       <feGaussianBlur stdDeviation="3" result="blur"/>
@@ -29,32 +29,32 @@
   <rect x="0" y="296" width="1200" height="4" fill="url(#accentGrad)"/>
 
   <g opacity="0.06">
-    <line x1="0" y1="40" x2="1200" y2="40" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="0" y1="80" x2="1200" y2="80" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="0" y1="120" x2="1200" y2="120" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="0" y1="160" x2="1200" y2="160" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="0" y1="200" x2="1200" y2="200" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="0" y1="240" x2="1200" y2="240" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="100" y1="0" x2="100" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="200" y1="0" x2="200" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="300" y1="0" x2="300" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="400" y1="0" x2="400" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="500" y1="0" x2="500" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="600" y1="0" x2="600" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="700" y1="0" x2="700" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="800" y1="0" x2="800" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="900" y1="0" x2="900" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="1000" y1="0" x2="1000" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
-    <line x1="1100" y1="0" x2="1100" y2="300" stroke="#a78bfa" stroke-width="0.5"/>
+    <line x1="0" y1="40" x2="1200" y2="40" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="0" y1="80" x2="1200" y2="80" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="0" y1="120" x2="1200" y2="120" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="0" y1="160" x2="1200" y2="160" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="0" y1="200" x2="1200" y2="200" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="0" y1="240" x2="1200" y2="240" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="100" y1="0" x2="100" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="200" y1="0" x2="200" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="300" y1="0" x2="300" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="400" y1="0" x2="400" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="500" y1="0" x2="500" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="600" y1="0" x2="600" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="700" y1="0" x2="700" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="800" y1="0" x2="800" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="900" y1="0" x2="900" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="1000" y1="0" x2="1000" y2="300" stroke="#E8926F" stroke-width="0.5"/>
+    <line x1="1100" y1="0" x2="1100" y2="300" stroke="#E8926F" stroke-width="0.5"/>
   </g>
 
   <g transform="translate(80, 90)">
-    <rect width="100" height="100" rx="20" fill="#1e1e3f" stroke="#6366f1" stroke-width="2"/>
-    <g transform="translate(50,50)" fill="none" stroke="#a78bfa" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)">
+    <rect width="100" height="100" rx="20" fill="#252636" stroke="#D97757" stroke-width="2"/>
+    <g transform="translate(50,50)" fill="none" stroke="#E8926F" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" filter="url(#glow)">
       <path d="M-22,-15 L-8,-15 L0,-7 L8,-15 L22,-15" />
       <path d="M-15,-7 L-15,12 Q-15,20 -7,20 L7,20 Q15,20 15,12 L15,-7" />
-      <circle cx="-7" cy="4" r="3" fill="#a78bfa" stroke="none"/>
-      <circle cx="7" cy="4" r="3" fill="#a78bfa" stroke="none"/>
+      <circle cx="-7" cy="4" r="3" fill="#E8926F" stroke="none"/>
+      <circle cx="7" cy="4" r="3" fill="#E8926F" stroke="none"/>
       <path d="M-5,12 Q0,17 5,12" />
     </g>
   </g>
@@ -62,29 +62,29 @@
   <g transform="translate(220, 95)">
     <text font-family="system-ui, -apple-system, sans-serif" font-size="52" font-weight="700" fill="white" filter="url(#softGlow)">Pro Workflow</text>
     <text font-family="system-ui, -apple-system, sans-serif" font-size="52" font-weight="700" fill="white">Pro Workflow</text>
-    <text y="38" font-family="'SF Mono', 'Fira Code', monospace" font-size="16" fill="#a78bfa" letter-spacing="3">v2.0</text>
+    <text y="38" font-family="'SF Mono', 'Fira Code', monospace" font-size="16" fill="#E8926F" letter-spacing="3">v2.0</text>
     <text y="70" font-family="system-ui, -apple-system, sans-serif" font-size="18" fill="#94a3b8">Complete AI coding workflow system</text>
   </g>
 
   <g transform="translate(220, 210)">
-    <rect x="0" y="0" width="130" height="30" rx="15" fill="#1e1e3f" stroke="#6366f1" stroke-width="1"/>
-    <text x="65" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#a78bfa">10 Patterns</text>
+    <rect x="0" y="0" width="130" height="30" rx="15" fill="#252636" stroke="#D97757" stroke-width="1"/>
+    <text x="65" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#E8926F">10 Patterns</text>
 
-    <rect x="145" y="0" width="110" height="30" rx="15" fill="#1e1e3f" stroke="#6366f1" stroke-width="1"/>
-    <text x="200" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#a78bfa">5 Agents</text>
+    <rect x="145" y="0" width="110" height="30" rx="15" fill="#252636" stroke="#D97757" stroke-width="1"/>
+    <text x="200" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#E8926F">5 Agents</text>
 
-    <rect x="270" y="0" width="120" height="30" rx="15" fill="#1e1e3f" stroke="#6366f1" stroke-width="1"/>
-    <text x="330" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#a78bfa">18 Hooks</text>
+    <rect x="270" y="0" width="120" height="30" rx="15" fill="#252636" stroke="#D97757" stroke-width="1"/>
+    <text x="330" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#E8926F">18 Hooks</text>
 
-    <rect x="405" y="0" width="130" height="30" rx="15" fill="#1e1e3f" stroke="#6366f1" stroke-width="1"/>
-    <text x="470" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#a78bfa">11 Skills</text>
+    <rect x="405" y="0" width="130" height="30" rx="15" fill="#252636" stroke="#D97757" stroke-width="1"/>
+    <text x="470" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#E8926F">11 Skills</text>
 
-    <rect x="550" y="0" width="130" height="30" rx="15" fill="#1e1e3f" stroke="#6366f1" stroke-width="1"/>
-    <text x="615" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#a78bfa">7 Guides</text>
+    <rect x="550" y="0" width="130" height="30" rx="15" fill="#252636" stroke="#D97757" stroke-width="1"/>
+    <text x="615" y="20" text-anchor="middle" font-family="'SF Mono', monospace" font-size="12" fill="#E8926F">7 Guides</text>
   </g>
 
   <g transform="translate(900, 60)" opacity="0.15">
-    <text font-family="'SF Mono', monospace" font-size="11" fill="#a78bfa">
+    <text font-family="'SF Mono', monospace" font-size="11" fill="#E8926F">
       <tspan x="0" dy="0">$ claude --worktree</tspan>
       <tspan x="0" dy="18">$ /develop add auth</tspan>
       <tspan x="0" dy="18">  Research... GO (85/100)</tspan>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#6366f1;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#D97757;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#D97757;stop-opacity:1" />
     </linearGradient>
   </defs>
   <rect width="128" height="128" rx="24" fill="url(#bg)"/>

--- a/assets/self-correction-demo.svg
+++ b/assets/self-correction-demo.svg
@@ -22,7 +22,7 @@
     <text x="60" y="65" fill="#cdd6f4"> No, that's the wrong file. The utils are in src/lib/</text>
 
     <!-- Claude acknowledges -->
-    <text x="20" y="100" fill="#cba6f7">claude:</text>
+    <text x="20" y="100" fill="#D97757">claude:</text>
     <text x="85" y="100" fill="#cdd6f4"> You're right. I edited src/utils.ts but should have</text>
     <text x="85" y="118" fill="#cdd6f4"> edited src/lib/utils.ts.</text>
 

--- a/assets/workflow-flow.svg
+++ b/assets/workflow-flow.svg
@@ -1,11 +1,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 280" width="900" height="280">
   <defs>
     <linearGradient id="bg3" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#0f0f23;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#1a1a3e;stop-opacity:1" />
+      <stop offset="0%" style="stop-color:#191A23;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1E1F2E;stop-opacity:1" />
     </linearGradient>
     <marker id="arr" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
-      <polygon points="0 0, 8 3, 0 6" fill="#6366f1"/>
+      <polygon points="0 0, 8 3, 0 6" fill="#D97757"/>
     </marker>
     <marker id="arrG" markerWidth="8" markerHeight="6" refX="8" refY="3" orient="auto">
       <polygon points="0 0, 8 3, 0 6" fill="#22c55e"/>
@@ -18,24 +18,24 @@
   <text x="450" y="52" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#64748b">Multi-phase development with validation gates</text>
 
   <!-- Phase 1: Research -->
-  <rect x="30" y="75" width="160" height="80" rx="10" fill="#1e1e3f" stroke="#6366f1" stroke-width="2"/>
-  <text x="110" y="100" text-anchor="middle" font-family="'SF Mono', monospace" font-size="13" fill="#a78bfa" font-weight="600">1. Research</text>
+  <rect x="30" y="75" width="160" height="80" rx="10" fill="#252636" stroke="#D97757" stroke-width="2"/>
+  <text x="110" y="100" text-anchor="middle" font-family="'SF Mono', monospace" font-size="13" fill="#E8926F" font-weight="600">1. Research</text>
   <text x="110" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Explore codebase</text>
   <text x="110" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Score confidence</text>
   <text x="110" y="146" text-anchor="middle" font-family="'SF Mono', monospace" font-size="10" fill="#22c55e">GO if >= 70</text>
 
   <!-- Arrow -->
-  <line x1="190" y1="115" x2="230" y2="115" stroke="#6366f1" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="190" y1="115" x2="230" y2="115" stroke="#D97757" stroke-width="2" marker-end="url(#arr)"/>
 
   <!-- Gate 1 -->
   <polygon points="240,95 260,115 240,135 220,115" fill="none" stroke="#f59e0b" stroke-width="2"/>
   <text x="240" y="119" text-anchor="middle" font-family="'SF Mono', monospace" font-size="9" fill="#fbbf24">GO?</text>
 
   <!-- Arrow -->
-  <line x1="260" y1="115" x2="295" y2="115" stroke="#6366f1" stroke-width="2" marker-end="url(#arr)"/>
+  <line x1="260" y1="115" x2="295" y2="115" stroke="#D97757" stroke-width="2" marker-end="url(#arr)"/>
 
   <!-- Phase 2: Plan -->
-  <rect x="300" y="75" width="160" height="80" rx="10" fill="#1e1e3f" stroke="#f59e0b" stroke-width="2"/>
+  <rect x="300" y="75" width="160" height="80" rx="10" fill="#252636" stroke="#f59e0b" stroke-width="2"/>
   <text x="380" y="100" text-anchor="middle" font-family="'SF Mono', monospace" font-size="13" fill="#fbbf24" font-weight="600">2. Plan</text>
   <text x="380" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Design solution</text>
   <text x="380" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">List all changes</text>
@@ -46,14 +46,14 @@
 
   <!-- Gate 2 -->
   <polygon points="510,95 530,115 510,135 490,115" fill="none" stroke="#22c55e" stroke-width="2"/>
-  <text x="510" y="119" text-anchor="middle" font-family="'SF Mono', monospace" font-size="8" fill="#4ade80">OK?</text>
+  <text x="510" y="119" text-anchor="middle" font-family="'SF Mono', monospace" font-size="8" fill="#2DD4A8">OK?</text>
 
   <!-- Arrow -->
   <line x1="530" y1="115" x2="565" y2="115" stroke="#22c55e" stroke-width="2" marker-end="url(#arrG)"/>
 
   <!-- Phase 3: Implement -->
-  <rect x="570" y="75" width="160" height="80" rx="10" fill="#1e1e3f" stroke="#22c55e" stroke-width="2"/>
-  <text x="650" y="100" text-anchor="middle" font-family="'SF Mono', monospace" font-size="13" fill="#4ade80" font-weight="600">3. Implement</text>
+  <rect x="570" y="75" width="160" height="80" rx="10" fill="#252636" stroke="#22c55e" stroke-width="2"/>
+  <text x="650" y="100" text-anchor="middle" font-family="'SF Mono', monospace" font-size="13" fill="#2DD4A8" font-weight="600">3. Implement</text>
   <text x="650" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Execute plan</text>
   <text x="650" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Quality gates / 5 edits</text>
   <text x="650" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Run tests</text>
@@ -62,21 +62,21 @@
   <line x1="730" y1="115" x2="770" y2="115" stroke="#22c55e" stroke-width="2" marker-end="url(#arrG)"/>
 
   <!-- Phase 4: Review -->
-  <rect x="775" y="75" width="100" height="80" rx="10" fill="#1e1e3f" stroke="#ef4444" stroke-width="2"/>
+  <rect x="775" y="75" width="100" height="80" rx="10" fill="#252636" stroke="#ef4444" stroke-width="2"/>
   <text x="825" y="100" text-anchor="middle" font-family="'SF Mono', monospace" font-size="13" fill="#f87171" font-weight="600">4. Review</text>
   <text x="825" y="118" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Security</text>
   <text x="825" y="132" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Quality</text>
   <text x="825" y="146" text-anchor="middle" font-family="system-ui, sans-serif" font-size="10" fill="#94a3b8">Commit</text>
 
   <!-- Bottom: What fires at each step -->
-  <rect x="30" y="185" width="845" height="75" rx="10" fill="#0d0d1f" stroke="#334155" stroke-width="1"/>
+  <rect x="30" y="185" width="845" height="75" rx="10" fill="#14151F" stroke="#334155" stroke-width="1"/>
   <text x="450" y="205" text-anchor="middle" font-family="'SF Mono', monospace" font-size="11" fill="#64748b">Hooks firing throughout:</text>
 
-  <text x="80" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#6366f1">SubagentStart</text>
+  <text x="80" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#D97757">SubagentStart</text>
   <text x="210" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#f59e0b">UserPromptSubmit</text>
   <text x="370" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#22c55e">PostToolUse</text>
   <text x="500" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#ef4444">PreToolUse</text>
-  <text x="620" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#a78bfa">TaskCompleted</text>
+  <text x="620" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#E8926F">TaskCompleted</text>
   <text x="770" y="228" font-family="'SF Mono', monospace" font-size="10" fill="#fbbf24">Stop</text>
 
   <text x="80" y="248" font-family="'SF Mono', monospace" font-size="10" fill="#64748b">drift-detector</text>

--- a/docs/infographic.html
+++ b/docs/infographic.html
@@ -680,7 +680,7 @@
       <div class="header-sub" style="margin-left: 18px;">github.com/rohitg00/pro-workflow</div>
     </div>
     <div class="header-right">
-      <div class="star-count">v1.3</div>
+      <div class="star-count">v2.0</div>
       <div class="star-label">Latest Release</div>
     </div>
   </div>
@@ -691,7 +691,7 @@
     <div class="subtitle">
       Battle-tested Claude Code patterns from power users who ship production code daily.
       Self-correcting memory, parallel worktrees, quality gates, and the 80/20 AI coding ratio &mdash;
-      9 Skills, 3 Agents, 12 Hooks, 10 Commands, 3 Contexts.
+      11 Skills, 5 Agents, 18 Hooks, 10 Commands, 3 Contexts, 7 Guides.
     </div>
   </div>
 
@@ -750,13 +750,14 @@
     <div>
       <div class="section-num">03 Components</div>
       <div class="section-title">Everything Included</div>
-      <div class="comp-grid" style="grid-template-columns: repeat(3, 1fr);">
-        <div class="comp-item"><div class="comp-num">9</div><div class="comp-label">Skills</div></div>
-        <div class="comp-item"><div class="comp-num">3</div><div class="comp-label">Agents</div></div>
-        <div class="comp-item"><div class="comp-num">12</div><div class="comp-label">Hooks</div></div>
+      <div class="comp-grid" style="grid-template-columns: repeat(4, 1fr);">
+        <div class="comp-item"><div class="comp-num">11</div><div class="comp-label">Skills</div></div>
+        <div class="comp-item"><div class="comp-num">5</div><div class="comp-label">Agents</div></div>
+        <div class="comp-item"><div class="comp-num">18</div><div class="comp-label">Hooks</div></div>
         <div class="comp-item"><div class="comp-num">10</div><div class="comp-label">Commands</div></div>
         <div class="comp-item"><div class="comp-num">3</div><div class="comp-label">Contexts</div></div>
         <div class="comp-item"><div class="comp-num">6</div><div class="comp-label">Rules</div></div>
+        <div class="comp-item"><div class="comp-num">7</div><div class="comp-label">Guides</div></div>
       </div>
       <div style="margin-top:14px;">
         <div style="font-size:10px; font-weight:700; letter-spacing:1.5px; text-transform:uppercase; color:var(--anthro-muted); margin-bottom:6px;">Platforms</div>
@@ -859,7 +860,7 @@
     <!-- 06 HOOKS & AUTOMATION -->
     <div>
       <div class="section-num">06 Hooks &amp; Automation</div>
-      <div class="section-title">12 Automated Hooks</div>
+      <div class="section-title">18 Hook Events</div>
       <div class="hook-grid">
         <div class="hook-item">
           <div class="hook-dot hook-dot-pre"></div>
@@ -905,6 +906,34 @@
           <div class="hook-dot hook-dot-other"></div>
           <div><div class="hook-name">Notification</div><div class="hook-desc">Permission logging</div></div>
         </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">SubagentStart</div><div class="hook-desc">Agent lifecycle logging</div></div>
+        </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">SubagentStop</div><div class="hook-desc">Collect agent results</div></div>
+        </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">TaskCompleted</div><div class="hook-desc">Quality gate on completion</div></div>
+        </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">PermissionRequest</div><div class="hook-desc">Flag dangerous ops</div></div>
+        </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">PostToolUseFailure</div><div class="hook-desc">Track failures</div></div>
+        </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">TeammateIdle</div><div class="hook-desc">Detect blockers</div></div>
+        </div>
+        <div class="hook-item">
+          <div class="hook-dot hook-dot-other"></div>
+          <div><div class="hook-name">Setup</div><div class="hook-desc">One-time initialization</div></div>
+        </div>
       </div>
       <div style="display:flex; gap:8px; margin-top:10px;">
         <div style="display:flex; align-items:center; gap:4px;"><div class="hook-dot hook-dot-pre" style="width:6px;height:6px;"></div><span style="font-size:9px; color:var(--anthro-muted);">Pre</span></div>
@@ -923,7 +952,7 @@
     <!-- 07 THREE AGENTS -->
     <div>
       <div class="section-num">07 Specialized Agents</div>
-      <div class="section-title">3 Purpose-Built Agents</div>
+      <div class="section-title">5 Specialized Agents</div>
       <div style="display:flex; flex-direction:column; gap:10px;">
         <div class="card card-coral">
           <div style="display:flex; justify-content:space-between; align-items:center;">
@@ -956,6 +985,30 @@
             <span class="tag">Confidence Gate</span>
           </div>
           <div style="font-size:11px; color:var(--anthro-muted); margin-top:4px;">Assess readiness with worktree isolation. Scores 0&ndash;100 across 5 dimensions.</div>
+        </div>
+        <div class="card card-coral">
+          <div style="display:flex; justify-content:space-between; align-items:center;">
+            <div style="font-size:15px; font-weight:800; color:var(--anthro-dark);">Orchestrator</div>
+            <span class="tag">Memory-Enabled</span>
+          </div>
+          <div style="font-size:11px; color:var(--anthro-muted); margin-top:4px;">Multi-phase feature development. Research &gt; Plan &gt; Implement &gt; Review workflow.</div>
+          <div class="tag-row" style="margin-top:8px;">
+            <span class="tag">/develop</span>
+            <span class="tag">Multi-Phase</span>
+            <span class="tag">Validation Gates</span>
+          </div>
+        </div>
+        <div class="card card-coral">
+          <div style="display:flex; justify-content:space-between; align-items:center;">
+            <div style="font-size:15px; font-weight:800; color:var(--anthro-dark);">Debugger</div>
+            <span class="tag">Hypothesis-Driven</span>
+          </div>
+          <div style="font-size:11px; color:var(--anthro-muted); margin-top:4px;">Systematic bug investigation with root cause analysis and fix verification.</div>
+          <div class="tag-row" style="margin-top:8px;">
+            <span class="tag">Root Cause</span>
+            <span class="tag">Reproduce</span>
+            <span class="tag">Verify Fix</span>
+          </div>
         </div>
       </div>
     </div>
@@ -1063,7 +1116,7 @@
     <!-- 10 SKILLS -->
     <div>
       <div class="section-num">10 Skills Library</div>
-      <div class="section-title">9 Battle-Tested Skills</div>
+      <div class="section-title">11 Skills</div>
       <table>
         <tr><th>Skill</th><th>What It Does</th></tr>
         <tr><td><strong>pro-workflow</strong></td><td>Core 8 patterns</td></tr>
@@ -1075,6 +1128,8 @@
         <tr><td><strong>session-handoff</strong></td><td>Resume docs for next session</td></tr>
         <tr><td><strong>insights</strong></td><td>Analytics, heatmaps, trends</td></tr>
         <tr><td><strong>deslop</strong></td><td>Remove AI code slop before commit</td></tr>
+        <tr><td><strong>context-optimizer</strong></td><td>Token management and MCP audit</td></tr>
+        <tr><td><strong>orchestrate</strong></td><td>Wire Commands, Agents, Skills for multi-phase dev</td></tr>
       </table>
     </div>
 
@@ -1156,8 +1211,8 @@
   <!-- FOOTER -->
   <div class="footer">
     <div class="footer-left">
-      By <strong>Rohit Ghumare</strong> &middot; github.com/rohitg00/pro-workflow &middot; Feb 2026<br>
-      Based on patterns from Boris Cherny, Andrej Karpathy, and Claude Code power users
+      By <strong>Rohit Ghumare</strong> &middot; github.com/rohitg00/pro-workflow &middot; Mar 2026<br>
+      Pro Workflow v2.0 &mdash; Battle-tested patterns from Boris Cherny, Andrej Karpathy, and Claude Code power users
     </div>
     <div class="footer-right">Practice Makes Claude Perfect</div>
   </div>


### PR DESCRIPTION
## Summary
- Rebrand all SVGs from purple/indigo to Anthropic coral (#D97757, #E8926F) with navy backgrounds (#191A23)
- Update infographic.html from v1.3 to v2.0 with correct component counts (11 skills, 5 agents, 18 hooks, 7 guides)
- Update README badge and mermaid diagram colors to match Anthropic brand

## Changes
**SVGs (5 files):** banner, logo, architecture, workflow-flow, self-correction-demo — all recolored from purple (#6366f1) to Anthropic coral (#D97757)

**Infographic HTML:** v1.3 → v2.0, added orchestrator/debugger agents, context-optimizer/orchestrate skills, 7 new hook events (SubagentStart, SubagentStop, TaskCompleted, PermissionRequest, PostToolUseFailure, TeammateIdle, Setup), 7 Guides component

**README:** Badge colors and mermaid diagram styles updated

## Test plan
- [ ] Verify SVGs render correctly on GitHub (dark and light mode)
- [ ] Open `docs/infographic.html` in browser and verify layout
- [ ] Check README badges load with new coral colors
- [ ] Verify mermaid diagrams render with updated styles