### PR TITLE
fix: use GITHUB_OUTPUT for release changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,15 +57,19 @@ jobs:
         run: |
           # Get previous tag
           PREV_TAG=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
-          
+
           if [ -z "$PREV_TAG" ]; then
             CHANGES=$(git log --pretty=format:"- %s" HEAD)
           else
             CHANGES=$(git log --pretty=format:"- %s" ${PREV_TAG}..HEAD)
           fi
-          
-          # Write to file for multiline output
-          echo "$CHANGES" > /tmp/changelog.txt
+
+          # Use multiline GITHUB_OUTPUT syntax
+          {
+            echo "CHANGES<<EOF"
+            echo "$CHANGES"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
           echo "Generated changelog with $(echo "$CHANGES" | wc -l) commits"
 
       - name: Create GitHub Release
@@ -74,8 +78,8 @@ jobs:
           name: pro-workflow v${{ steps.version.outputs.VERSION }}
           body: |
             ## What's Changed
-            
-            $(cat /tmp/changelog.txt)
+
+            ${{ steps.changelog.outputs.CHANGES }}
             
             ## Installation
             


### PR DESCRIPTION
## Summary

- The release workflow `body` field used `$(cat /tmp/changelog.txt)` which is shell command substitution — but inside YAML it's treated as **literal text**, so the release page shows `$(cat /tmp/changelog.txt)` instead of the actual changelog.
- Switch to multiline `GITHUB_OUTPUT` heredoc syntax and reference the output via `${{ steps.changelog.outputs.CHANGES }}` so the changelog is correctly interpolated.

## Test plan

- [x] Create a test tag (e.g. `v2.0.0`) and verify the generated GitHub Release body contains actual commit messages instead of `$(cat /tmp/changelog.txt)`
<img width="1502" height="739" alt="image" src="https://github.com/user-attachments/assets/0e48ca32-0554-47aa-84ed-b9999dc6deec" />


## Fix
<img width="1199" height="805" alt="image" src="https://github.com/user-attachments/assets/6a9ba04b-2d40-44ab-a7ca-58feeb3b86d3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal release workflow automation.
  * Release notes generation now embeds the changelog directly into the release body for more reliable, single-step publication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->