### PR TITLE
ci: add automated skill review for SKILL.md pull requests

### DIFF
--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -1,0 +1,14 @@
+name: Skill Review
+on:
+  pull_request:
+    paths: ['**/SKILL.md']
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/skill-review@main


### PR DESCRIPTION
Hullo! Thanks for merging the skill improvements earlier. This is a follow-up that adds a lightweight GitHub Action to automatically review any `SKILL.md` files when they're changed in a PR, using tessl skill review.

- Triggers only on PRs that touch **/SKILL.md
- Posts review results as a PR comment
- Minimal permissions: pull-requests: write and contents: read

This way you and your contributors get an instant quality signal on skill changes before manual review — no signup or tokens needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated skill review workflow that executes on pull requests modifying skill-related files, enabling continuous quality validation and streamlining the review process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->