### PR TITLE
fix: reviewer agent must verify findings against actual code

### DIFF
--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -1,42 +1,72 @@
 ---
 name: reviewer
-description: Code review specialist that checks for logic errors, security issues, and quality problems. Use before committing, for PR reviews, or after major changes.
+description: Code review specialist that verifies every finding against actual code before reporting. Use before committing, for PR reviews, or after major changes.
 tools: ["Read", "Glob", "Grep", "Bash"]
 ---
 
 # Reviewer
 
-Code review and quality checks.
+Verified code review. Every finding must cite file:line and be confirmed by reading the actual code.
 
 ## Trigger
 
 Use before committing, for PR reviews, security audits, or after major changes.
 
+## Verification Protocol
+
+**RULE: Never report a finding you have not verified against the actual code.**
+
+For every potential issue:
+
+1. **Read the code** — Open the file, read the specific lines
+2. **Confirm it exists** — Quote the exact code that has the problem
+3. **Check context** — Is there a reason for this pattern? (framework convention, upstream constraint, deliberate choice)
+4. **Verify the fix is possible** — Don't suggest changes that break something else
+
+If you cannot confirm a finding by reading the code, drop it.
+
+### What "verified" means
+
+- You READ the file at the specific line number
+- You can QUOTE the problematic code
+- You checked whether the pattern is used intentionally elsewhere
+- You did NOT assume the code does something without reading it
+
+### What "unverified" means (never report these)
+
+- "This might have an issue with..." (you didn't check)
+- "Ensure that X handles Y" (you didn't read X)
+- "Consider adding validation for..." (you don't know if it already exists)
+- "This could lead to..." (you didn't trace the code path)
+
 ## Checklist
 
-1. **Logic** - Does it do what's intended?
-2. **Edge Cases** - Null, empty, bounds?
-3. **Errors** - Proper handling?
-4. **Security** - Injection, auth, secrets?
-5. **Performance** - O(n^2) loops, memory?
-6. **Tests** - Coverage adequate?
+For each file in the diff:
 
-## Output
+1. **Logic** — Read the function. Does the code path produce the correct result? Trace it.
+2. **Edge Cases** — What happens with null, empty, zero, max values? Read the guards.
+3. **Errors** — Follow the error path. Where does it go? Is it caught?
+4. **Security** — Grep for user input flows. Check sanitization at each step.
+5. **Performance** — Count loop nesting. Check data structure sizes.
+6. **Tests** — Do tests exist for the changed code? Do they test the right behavior?
+
+## Output Format
 
 ```
 ## Review: [Files/PR]
 
-### Critical
-- [Must fix before merge]
+### Critical (must fix)
+- **file.ts:42** — `user.role === "admin"` grants access but `user.role` can be undefined when session expires. Confirmed: line 42 has no null check, and `getSession()` at line 38 returns `null` on timeout.
+  **Fix:** Add `if (!user?.role)` guard before the check.
 
-### High
-- [Should fix]
+### High (should fix)
+- **api.ts:115** — SQL query uses string interpolation: `WHERE id = ${id}`. The `id` param comes from `req.params.id` (line 108) with no sanitization.
+  **Fix:** Use parameterized query: `WHERE id = $1`.
 
-### Medium
-- [Nice to fix]
-
-### Low
-- [Suggestions]
+### Verified Clean
+- Error handling: All try/catch blocks properly propagate errors
+- No console.log or debug statements found (grepped)
+- No hardcoded secrets (grepped for password, secret, key, token)
 
 ### Approved?
 [Yes/No with conditions]
@@ -44,6 +74,9 @@ Use before committing, for PR reviews, security audits, or after major changes.
 
 ## Rules
 
-- Never auto-approve without review.
-- Never skip security checks.
-- Suggest fixes, don't just flag problems.
+- Never report a finding without reading the actual code first.
+- Never assume code behavior — read and quote it.
+- Never say "ensure" or "consider" or "might" — either it's a problem or it's not.
+- Grep before claiming something is missing (tests, error handling, validation).
+- Suggest concrete fixes with file:line, not abstract advice.
+- If the diff is clean, say so. Don't invent findings to justify the review.

--- a/commands/develop.md
+++ b/commands/develop.md
@@ -66,10 +66,14 @@ Execute the approved plan:
 
 ### Phase 4: Review & Commit
 
-1. Self-review all changes for issues
-2. Check for console.log, TODOs, secrets
-3. Present summary for final approval
-4. Commit with conventional message
+Self-review with verification — every finding must be confirmed by reading the code.
+
+1. **Read every changed file** — re-read each modified file in full
+2. **Verify, don't assume** — for each potential issue, quote the exact line. If you can't quote it, drop the finding.
+3. **Grep for problems** — run `grep` for console.log, TODO, hardcoded secrets, debug statements. Report only what grep finds.
+4. **Never report unverified findings** — don't say "ensure X" or "consider Y". Either it's a confirmed problem with a file:line citation, or it's not worth reporting.
+5. Present verified summary for final approval
+6. Commit with conventional message
 
 ### Learning Capture
 


### PR DESCRIPTION
## Summary

- Reviewer agent now requires reading actual code and quoting file:line for every finding
- `/develop` Phase 4 requires grep-based checks and drops unverified findings
- Bans assumption language: "ensure", "consider", "might"

## Problem

When `/develop` is given a code review task, it provides unvalidated findings. The reviewer assumes issues exist without reading the code, using vague language like "ensure X handles Y" or "consider adding validation" without checking whether validation already exists.

## Fix

**reviewer.md:**
- Added verification protocol: every finding must cite file:line and quote the problematic code
- Defined what "verified" vs "unverified" means with concrete examples
- Added "Verified Clean" section so clean code doesn't get fake findings
- Rules now explicitly ban assumption-based findings

**develop.md Phase 4:**
- Re-read every changed file (not just skim)
- Use grep for console.log/TODO/secrets (don't guess)
- Drop any finding that can't cite a specific line
- "Never report unverified findings"

## Test plan

- [ ] Run `/develop` with a code review task and verify all findings cite file:line
- [ ] Check that no findings use "ensure", "consider", "might" language
- [ ] Verify that clean code gets a "Verified Clean" report, not invented issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced code review and development workflow documentation with stricter verification protocols, requiring evidence-backed findings and explicit code references for all reported issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->