### PR TITLE
feat: add protect-mcp to recommended MCP servers

### DIFF
--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -18,6 +18,12 @@
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       },
       "_comment": "PRs, issues, code search. Essential for any GitHub-based project."
+    },
+    "_protect-mcp": {
+      "command": "npx",
+      "args": ["-y", "protect-mcp", "serve", "--enforce"],
+      "_comment": "Uncomment (remove leading underscore) to enable. Signs Ed25519 receipts for every tool call. Cedar policy enforcement. Zero config — auto-generates policies on first run. See https://www.npmjs.com/package/protect-mcp",
+      "_when": "Compliance requirements, multi-agent orchestration, audit trails, or when agents handle sensitive operations."
     }
   },
   "_recommendations": {
@@ -27,6 +33,7 @@
       "github - PRs, issues, code search."
     ],
     "add_when_needed": [
+      "protect-mcp - Cryptographic receipt signing for tool calls (when you need audit trails, policy enforcement, or compliance evidence)",
       "supabase - Database operations (when using Supabase)",
       "linear - Issue tracking (when using Linear)",
       "slack - Team notifications (when using Slack)"

--- a/mcp-config.example.json
+++ b/mcp-config.example.json
@@ -18,11 +18,15 @@
         "GITHUB_PERSONAL_ACCESS_TOKEN": "${GITHUB_TOKEN}"
       },
       "_comment": "PRs, issues, code search. Essential for any GitHub-based project."
-    },
-    "_protect-mcp": {
+    }
+  },
+  "_optional_servers": {
+    "_note": "Copy into mcpServers above to enable. These are not loaded by default.",
+    "protect-mcp": {
       "command": "npx",
-      "args": ["-y", "protect-mcp", "serve", "--enforce"],
-      "_comment": "Uncomment (remove leading underscore) to enable. Signs Ed25519 receipts for every tool call. Cedar policy enforcement. Zero config — auto-generates policies on first run. See https://www.npmjs.com/package/protect-mcp",
+      "args": ["-y", "protect-mcp@0.5.2", "serve", "--enforce"],
+      "_comment": "Ed25519 receipt signing + Cedar policy enforcement for every tool call. Zero config — auto-generates policies on first run.",
+      "_docs": "https://www.npmjs.com/package/protect-mcp",
       "_when": "Compliance requirements, multi-agent orchestration, audit trails, or when agents handle sensitive operations."
     }
   },


### PR DESCRIPTION
## What

Adds [protect-mcp](https://www.npmjs.com/package/protect-mcp) to the MCP config example:

1. **`add_when_needed` recommendation** — respects the "start with 3" philosophy
2. **Commented-out server entry** (prefixed with `_`) — users can uncomment when needed

## Why

Pro Workflow already has best-in-class hook coverage (24 events), but the hooks produce unsigned logs. protect-mcp complements this by adding:

- **Ed25519 receipt signing** for every tool call (tamper-evident audit trail)
- **Cedar policy enforcement** (same engine AWS uses for IAM)
- **Claude Code hooks integration** — runs as an HTTP hook server alongside Pro Workflow's command hooks

The two tools are complementary, not competing:
| | Pro Workflow | protect-mcp |
|---|---|---|
| **Focus** | Workflow optimization | Security enforcement |
| **Mechanism** | Command hooks + SQLite | HTTP hooks + Cedar policies |
| **Output** | Learnings, corrections, drift alerts | Signed receipts, allow/deny decisions |

## How to test

```bash
# The entry is commented out by default (prefixed with _)
# Users uncomment by removing the underscore: "_protect-mcp" → "protect-mcp"
npx protect-mcp serve --enforce  # starts hook server on :9377
```

## Context

- [npm: protect-mcp](https://www.npmjs.com/package/protect-mcp) (MIT)
- [Merged into Microsoft Agent Governance Toolkit](https://github.com/AzureAI-Foundry/agent-governance-toolkit/pull/667)
- [IETF Internet-Draft: draft-farley-acta-signed-receipts](https://datatracker.ietf.org/doc/draft-farley-acta-signed-receipts/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an example configuration for an optional MCP server, including guidance on how to enable and run it for users who want to activate the capability.
  * Extended recommendations to advise when to add this server—use cases include creating audit trails, enforcing policies, and producing compliance evidence; guidance explains when to adopt the example entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->