### PR TITLE
feat(hooks/rules/skills): deterministic hooks, git blast-radius guard, design rules

### DIFF
--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -25,6 +25,14 @@ If hooks aren't firing, check:
 - Script paths use `${CLAUDE_PLUGIN_ROOT}` or absolute paths
 - Scripts have execute permissions
 
+### 2a. Deterministic Hook Sanity
+Verify the commit validator and secret scanner run without an LLM:
+```bash
+echo '{"tool_input":{"command":"git commit -m \"feat: x\""}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/commit-validate.js" && echo "commit-validate: OK"
+echo '{"tool_input":{"content":"hello"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/secret-scan.js" && echo "secret-scan: OK"
+```
+Both should exit 0. These hooks used to depend on `"model": "haiku"` (fixed in issue #47).
+
 ### 3. Context Health
 ```text
 /context

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -26,12 +26,19 @@ If hooks aren't firing, check:
 - Scripts have execute permissions
 
 ### 2a. Deterministic Hook Sanity
-Verify the commit validator and secret scanner run without an LLM:
+Verify the hook scripts run without an LLM:
 ```bash
 echo '{"tool_input":{"command":"git commit -m \"feat: x\""}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/commit-validate.js" && echo "commit-validate: OK"
 echo '{"tool_input":{"content":"hello"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/secret-scan.js" && echo "secret-scan: OK"
+echo '{"tool_input":{"command":"ls"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/git-blast-radius.js" && echo "git-blast-radius: OK"
+echo '{"tool_input":{"command":"git reset --hard"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/git-blast-radius.js" 2>&1 | grep -q blocked && echo "git-blast-radius blocking: OK"
 ```
-Both should exit 0. These hooks used to depend on `"model": "haiku"` (fixed in issue #47).
+All should confirm OK. These hooks used to depend on `"model": "haiku"` (fixed in issue #47).
+
+### 2b. Git Safety Override
+If you need to run a blocked git operation deliberately (e.g. intentional
+`git reset --hard` during recovery), export `PRO_WORKFLOW_ALLOW_UNSAFE_GIT=1`
+for the shell that will run it. Never set it globally.
 
 ### 3. Context Health
 ```text

--- a/commands/doctor.md
+++ b/commands/doctor.md
@@ -26,14 +26,21 @@ If hooks aren't firing, check:
 - Scripts have execute permissions
 
 ### 2a. Deterministic Hook Sanity
-Verify the hook scripts run without an LLM:
+Verify each hook script on both happy and failing inputs:
 ```bash
-echo '{"tool_input":{"command":"git commit -m \"feat: x\""}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/commit-validate.js" && echo "commit-validate: OK"
-echo '{"tool_input":{"content":"hello"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/secret-scan.js" && echo "secret-scan: OK"
-echo '{"tool_input":{"command":"ls"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/git-blast-radius.js" && echo "git-blast-radius: OK"
-echo '{"tool_input":{"command":"git reset --hard"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/git-blast-radius.js" 2>&1 | grep -q blocked && echo "git-blast-radius blocking: OK"
+# commit-validate: valid passes, bad format blocks (exit 2)
+echo '{"tool_input":{"command":"git commit -m \"feat: x\""}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/commit-validate.js" && echo "commit-validate pass: OK"
+echo '{"tool_input":{"command":"git commit -m \"not conventional\""}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/commit-validate.js" 2>&1; test $? -eq 2 && echo "commit-validate block: OK"
+
+# secret-scan: clean passes, hardcoded key blocks
+echo '{"tool_input":{"content":"hello"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/secret-scan.js" && echo "secret-scan pass: OK"
+echo '{"tool_input":{"content":"key=\"AKIAIOSFODNN7EXAMPLE\""}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/secret-scan.js" 2>&1; test $? -eq 2 && echo "secret-scan block: OK"
+
+# git-blast-radius: safe passes, destructive blocks
+echo '{"tool_input":{"command":"git status"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/git-blast-radius.js" && echo "git-blast-radius pass: OK"
+echo '{"tool_input":{"command":"git reset --hard"}}' | node "$CLAUDE_PLUGIN_ROOT/scripts/git-blast-radius.js" 2>&1; test $? -eq 2 && echo "git-blast-radius block: OK"
 ```
-All should confirm OK. These hooks used to depend on `"model": "haiku"` (fixed in issue #47).
+Every line should print an `OK`. Missing any means the script is silently broken.
 
 ### 2b. Git Safety Override
 If you need to run a blocked git operation deliberately (e.g. intentional

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -66,14 +66,14 @@
         "description": "Git operation guards: quality gates before commit, LLM commit validation, wrap-up before push"
       },
       {
-        "matcher": "Write",
+        "matcher": "tool == \"Edit\" || tool == \"Write\"",
         "hooks": [
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/secret-scan.js\""
           }
         ],
-        "description": "Deterministic regex-based secret detection on file writes"
+        "description": "Deterministic regex-based secret detection on file writes and edits"
       }
     ],
     "PostToolUse": [

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -49,12 +49,9 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-commit-check.js\""
           },
           {
-            "type": "prompt",
+            "type": "command",
             "if": "Bash(git commit*)",
-            "prompt": "Check if this git commit message follows conventional commits format: <type>(<scope>): <summary>. Valid types: feat, fix, refactor, test, docs, chore, perf, ci, style. Summary must be under 72 chars. The commit input is: $ARGUMENTS. Return {\"ok\": true} if valid or missing -m flag, {\"ok\": false, \"reason\": \"...\"} if the message format is wrong.",
-            "model": "haiku",
-            "timeout": 15,
-            "statusMessage": "Validating commit message format..."
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/commit-validate.js\""
           },
           {
             "type": "command",
@@ -68,14 +65,11 @@
         "matcher": "Write",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Check if this file write contains hardcoded API keys, secrets, passwords, tokens, or private keys. Look for patterns like: AKIA*, sk-*, ghp_*, Bearer tokens, password=, secret=, private_key. The file content is: $ARGUMENTS. Return {\"ok\": true} if clean, {\"ok\": false, \"reason\": \"Found potential secret: [description]\"} if secrets detected.",
-            "model": "haiku",
-            "timeout": 15,
-            "statusMessage": "Scanning for secrets..."
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/secret-scan.js\""
           }
         ],
-        "description": "LLM-powered secret detection on file writes"
+        "description": "Deterministic regex-based secret detection on file writes"
       }
     ],
     "PostToolUse": [

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -45,6 +45,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/git-blast-radius.js\""
+          },
+          {
+            "type": "command",
             "if": "Bash(git commit*)",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/scripts/pre-commit-check.js\""
           },

--- a/rules/incremental-verify.mdc
+++ b/rules/incremental-verify.mdc
@@ -1,0 +1,41 @@
+---
+description: Verify each behavior before building the next. One test, one implementation, one commit. No bulk-writing tests for behavior that does not yet exist.
+globs:
+alwaysApply: true
+---
+
+# Incremental Verification
+
+## Principle
+
+Behavior you have not written cannot be tested honestly. Writing many tests
+before any implementation produces tests shaped by **imagined** behavior,
+not actual behavior — they assert on function signatures and data shapes,
+survive real regressions silently, and break on harmless refactors.
+
+## Rule
+
+For every new behavior: write one failing assertion, write the minimum
+implementation that makes it pass, commit, repeat. No batched test
+authoring. No scaffolding dozens of test cases before a single green run.
+
+## Checklist
+
+- [ ] Is there exactly one failing test right now? If more, split the commit.
+- [ ] Does the test exercise a public interface a caller would actually hit?
+- [ ] Would the test still make sense after a full internal refactor?
+- [ ] Was the implementation written **after** seeing the test fail?
+
+## Failure modes to catch
+
+- "Shape tests": asserting on object keys, array length, or types rather
+  than observable output. Rewrite against a caller's perspective.
+- "Mock-driven tests": the test mostly configures mocks then asserts the
+  mock was called. Move the mock to a system boundary or delete it.
+- "Green before red": if every test you wrote passed on the first run,
+  the test did not drive the design — treat it as suspect.
+
+## When to break the rule
+
+Exploratory spikes where you are probing an unknown API. Mark the spike
+branch as throwaway and do not merge its tests.

--- a/rules/module-shape.mdc
+++ b/rules/module-shape.mdc
@@ -1,0 +1,65 @@
+---
+description: Prefer modules with a narrow public surface and a thick internal implementation. Inject external dependencies at the boundary. Mock only at system edges.
+globs:
+alwaysApply: true
+---
+
+# Module Shape
+
+## Surface vs. depth
+
+A module's **surface** is every symbol a caller can touch: exported
+functions, class methods, config parameters, flags. A module's **depth**
+is everything hidden behind that surface: algorithms, branching, state
+machines, retries, caching.
+
+Aim for **narrow surface, thick depth**. A three-method module that hides
+a hundred lines of branching is strong. A thirty-method module whose
+methods each forward a single call to a dependency is weak — it leaks
+complexity upward without doing work.
+
+When adding a public export, first ask whether an existing one can absorb
+the new behavior. When removing, first ask whether the module has gone
+shallow and should be inlined into its only caller.
+
+## Dependency direction
+
+Accept dependencies as arguments. Do not construct external clients,
+fetch configuration, or read the clock inside business logic.
+
+```ts
+// strong: the caller owns lifecycle, the test swaps the gateway
+function chargeOrder(order, gateway) { return gateway.charge(order.total); }
+
+// weak: business logic welds itself to a vendor and a credential source
+function chargeOrder(order) {
+  const gateway = new AcmePay(process.env.ACME_KEY);
+  return gateway.charge(order.total);
+}
+```
+
+Return values, do not mutate inputs. `computeDiscount(cart) -> Discount`
+beats `applyDiscount(cart) -> void`. Pure returns are traceable; hidden
+mutation is not.
+
+## Where mocks belong
+
+Mock at system boundaries only: third-party HTTP APIs, databases when a
+real test instance is not available, the clock, random sources, the
+filesystem when tests must stay hermetic.
+
+Do not mock your own modules, internal classes, or anything you can
+instantiate cheaply. A test whose setup is twenty lines of mock wiring is
+telling you the module underneath is too shallow — fix the shape, not
+the test.
+
+At the real boundaries, prefer **endpoint-shaped** mocks over generic
+ones. `{ getUser(id), createOrder(data) }` beats `{ request(path, opts) }`
+because each mock returns one shape, test setup contains no conditionals,
+and a reader can see which calls a test exercises.
+
+## Checklist when reviewing
+
+- [ ] Does every public symbol justify its presence? Delete or merge the rest.
+- [ ] Are dependencies passed in, or constructed inside?
+- [ ] Do tests mock anything the module itself owns? If yes, the shape is wrong.

--- a/scripts/commit-validate.js
+++ b/scripts/commit-validate.js
@@ -13,16 +13,38 @@ function readStdin() {
 }
 
 function extractMessage(command) {
-  if (!command) return null;
-  const mFlag = command.match(/-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
-  if (mFlag) return (mFlag[1] || mFlag[2] || mFlag[3] || '').replace(/\\"/g, '"').replace(/\\'/g, "'");
-  const heredoc = command.match(/<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
-  if (heredoc) return heredoc[1].split('\n')[0];
-  return null;
+  if (!command) return { msg: null, form: 'empty' };
+
+  const shortFlag = command.match(/(?:^|\s)-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
+  if (shortFlag) {
+    const raw = shortFlag[1] || shortFlag[2] || shortFlag[3] || '';
+    return { msg: raw.replace(/\\"/g, '"').replace(/\\'/g, "'"), form: '-m' };
+  }
+
+  const longFlag = command.match(/--message(?:=|\s+)(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
+  if (longFlag) {
+    const raw = longFlag[1] || longFlag[2] || longFlag[3] || '';
+    return { msg: raw.replace(/\\"/g, '"').replace(/\\'/g, "'"), form: '--message' };
+  }
+
+  const heredocAny = command.match(/<<-?\s*'?([A-Za-z_][A-Za-z0-9_]*)'?\s*\n([\s\S]*?)\n\s*\1\s*$/m);
+  if (heredocAny) return { msg: heredocAny[2].split('\n')[0], form: 'heredoc' };
+
+  if (/(?:^|\s)-F(?:\s+\S+|=\S+)/.test(command) || /--file(?:=|\s+)\S+/.test(command)) {
+    return { msg: null, form: 'file' };
+  }
+
+  if (/\bgit\s+(?:-[^\s]+\s+)*commit\b/.test(command)) {
+    const afterCommit = command.split(/\bcommit\b/)[1] || '';
+    const hasExplicitFlag = /(?:-m|--message|-F|--file|--amend)\b/.test(afterCommit);
+    if (!hasExplicitFlag) return { msg: null, form: 'editor' };
+    return { msg: null, form: 'unknown' };
+  }
+
+  return { msg: null, form: 'empty' };
 }
 
 function validate(msg) {
-  if (!msg) return { ok: true };
   const firstLine = msg.split('\n')[0].trim();
   if (!PATTERN.test(firstLine)) {
     return { ok: false, reason: `Commit message must follow conventional commits: <type>(<scope>): <summary>. Valid types: ${TYPES.join(', ')}.` };
@@ -39,11 +61,19 @@ function validate(msg) {
   let input = {};
   try { input = JSON.parse(raw); } catch {}
   const command = input?.tool_input?.command || '';
-  const msg = extractMessage(command);
-  const result = validate(msg);
-  if (result.ok) {
+  const { msg, form } = extractMessage(command);
+
+  if (msg === null) {
+    if (form === 'file' || form === 'editor') process.exit(0);
+    if (form === 'unknown') {
+      console.error(`[pro-workflow] commit-validate: could not parse commit message from command; skipping validation. Review before pushing.`);
+      process.exit(0);
+    }
     process.exit(0);
   }
+
+  const result = validate(msg);
+  if (result.ok) process.exit(0);
   console.error(`[pro-workflow] commit-validate: ${result.reason}`);
   process.exit(2);
 })();

--- a/scripts/commit-validate.js
+++ b/scripts/commit-validate.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+const TYPES = ['feat', 'fix', 'refactor', 'test', 'docs', 'chore', 'perf', 'ci', 'style', 'build', 'revert'];
+const PATTERN = new RegExp(`^(${TYPES.join('|')})(\\([\\w\\-.,/ ]+\\))?!?: .+`);
+const MAX_SUMMARY = 72;
+
+function readStdin() {
+  return new Promise(resolve => {
+    let data = '';
+    process.stdin.on('data', c => { data += c; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+function extractMessage(command) {
+  if (!command) return null;
+  const mFlag = command.match(/-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
+  if (mFlag) return (mFlag[1] || mFlag[2] || mFlag[3] || '').replace(/\\"/g, '"').replace(/\\'/g, "'");
+  const heredoc = command.match(/<<'?EOF'?\s*\n([\s\S]*?)\nEOF/);
+  if (heredoc) return heredoc[1].split('\n')[0];
+  return null;
+}
+
+function validate(msg) {
+  if (!msg) return { ok: true };
+  const firstLine = msg.split('\n')[0].trim();
+  if (!PATTERN.test(firstLine)) {
+    return { ok: false, reason: `Commit message must follow conventional commits: <type>(<scope>): <summary>. Valid types: ${TYPES.join(', ')}.` };
+  }
+  const summary = firstLine.split(':').slice(1).join(':').trim();
+  if (summary.length > MAX_SUMMARY) {
+    return { ok: false, reason: `Commit summary is ${summary.length} chars, must be <= ${MAX_SUMMARY}.` };
+  }
+  return { ok: true };
+}
+
+(async () => {
+  const raw = await readStdin();
+  let input = {};
+  try { input = JSON.parse(raw); } catch {}
+  const command = input?.tool_input?.command || '';
+  const msg = extractMessage(command);
+  const result = validate(msg);
+  if (result.ok) {
+    process.exit(0);
+  }
+  console.error(`[pro-workflow] commit-validate: ${result.reason}`);
+  process.exit(2);
+})();

--- a/scripts/git-blast-radius.js
+++ b/scripts/git-blast-radius.js
@@ -1,20 +1,29 @@
 #!/usr/bin/env node
+const GIT_PREFIX = /\bgit(?:\s+(?:-[cC]\s+\S+|--\S+(?:=\S+)?|-[a-zA-Z]+))*\s+/;
+
+function sub(pattern) {
+  return new RegExp(GIT_PREFIX.source + pattern.source);
+}
+
 const BLOCK = [
-  { name: 'force push', re: /\bgit\s+push\s+(?:[^\s]+\s+)*(?:-f\b|--force\b)(?!-with-lease)/ },
-  { name: 'hard reset', re: /\bgit\s+reset\s+(?:[^\s]+\s+)*--hard\b/ },
-  { name: 'working-tree clean', re: /\bgit\s+clean\s+(?:[^\s]*f)/ },
-  { name: 'branch deletion (-D)', re: /\bgit\s+branch\s+(?:[^\s]+\s+)*-D\b/ },
-  { name: 'checkout discard (.)', re: /\bgit\s+checkout\s+(?:--\s+)?\.\s*$/ },
-  { name: 'restore discard (.)', re: /\bgit\s+restore\s+(?:[^\s]+\s+)*\.\s*$/ },
-  { name: 'interactive rebase on protected branch', re: /\bgit\s+rebase\s+(?:[^\s]+\s+)*-i\b.*\b(main|master|trunk|release\/)/ },
-  { name: 'history rewrite (filter-branch)', re: /\bgit\s+filter-branch\b/ },
-  { name: 'reflog expire', re: /\bgit\s+reflog\s+expire\b/ },
-  { name: 'ref deletion', re: /\bgit\s+update-ref\s+-d\b/ },
-  { name: 'stash drop/clear', re: /\bgit\s+stash\s+(?:drop|clear)\b/ },
+  { name: 'force push (--force / -f)',           re: sub(/push\s+(?:[^\s]+\s+)*(?:-f\b|--force\b)(?!-with-lease)/) },
+  { name: 'force push (refspec +branch)',        re: sub(/push\s+\S+\s+\+[^\s]+/) },
+  { name: 'remote branch delete (refspec :ref)', re: sub(/push\s+\S+\s+:[^\s]+/) },
+  { name: 'remote branch delete (--delete)',     re: sub(/push\s+(?:[^\s]+\s+)*--delete\b/) },
+  { name: 'hard reset',                          re: sub(/reset\s+(?:[^\s]+\s+)*--hard\b/) },
+  { name: 'working-tree clean',                  re: sub(/clean\s+(?:[^\s]*f)/) },
+  { name: 'branch deletion (-D)',                re: sub(/branch\s+(?:[^\s]+\s+)*-D\b/) },
+  { name: 'checkout discard (.)',                re: sub(/checkout\s+(?:--\s+)?\.\s*$/) },
+  { name: 'restore discard (.)',                 re: sub(/restore\s+(?:[^\s]+\s+)*\.\s*$/) },
+  { name: 'interactive rebase on protected branch', re: sub(/rebase\s+(?:[^\s]+\s+)*-i\b.*\b(?:main|master|trunk|release\/)/) },
+  { name: 'history rewrite (filter-branch)',     re: sub(/filter-branch\b/) },
+  { name: 'reflog expire',                       re: sub(/reflog\s+expire\b/) },
+  { name: 'ref deletion',                        re: sub(/update-ref\s+-d\b/) },
+  { name: 'stash drop/clear',                    re: sub(/stash\s+(?:drop|clear)\b/) },
 ];
 
 const WARN_NOT_BLOCK = [
-  { name: 'force-with-lease push', re: /\bgit\s+push\s+(?:[^\s]+\s+)*--force-with-lease\b/ },
+  { name: 'force-with-lease push', re: sub(/push\s+(?:[^\s]+\s+)*--force-with-lease\b/) },
 ];
 
 function readStdin() {
@@ -26,17 +35,22 @@ function readStdin() {
   });
 }
 
+function redact(command) {
+  return command.replace(/(https?:\/\/)[^/@\s]+@/gi, '$1***@');
+}
+
 (async () => {
   if (process.env.PRO_WORKFLOW_ALLOW_UNSAFE_GIT === '1') process.exit(0);
   const raw = await readStdin();
   let input = {};
   try { input = JSON.parse(raw); } catch {}
   const command = (input?.tool_input?.command || '').trim();
-  if (!command || !/^(?:.*\s)?git\s/.test(command)) process.exit(0);
+  if (!command || !/^(?:.*\s)?git\b/.test(command)) process.exit(0);
+  const safe = redact(command);
 
   for (const { name, re } of BLOCK) {
     if (re.test(command)) {
-      console.error(`[pro-workflow] git-blast-radius: blocked "${name}". Command: ${command}`);
+      console.error(`[pro-workflow] git-blast-radius: blocked "${name}". Command: ${safe}`);
       console.error(`Override for this shell: export PRO_WORKFLOW_ALLOW_UNSAFE_GIT=1`);
       process.exit(2);
     }

--- a/scripts/git-blast-radius.js
+++ b/scripts/git-blast-radius.js
@@ -1,0 +1,50 @@
+#!/usr/bin/env node
+const BLOCK = [
+  { name: 'force push', re: /\bgit\s+push\s+(?:[^\s]+\s+)*(?:-f\b|--force\b)(?!-with-lease)/ },
+  { name: 'hard reset', re: /\bgit\s+reset\s+(?:[^\s]+\s+)*--hard\b/ },
+  { name: 'working-tree clean', re: /\bgit\s+clean\s+(?:[^\s]*f)/ },
+  { name: 'branch deletion (-D)', re: /\bgit\s+branch\s+(?:[^\s]+\s+)*-D\b/ },
+  { name: 'checkout discard (.)', re: /\bgit\s+checkout\s+(?:--\s+)?\.\s*$/ },
+  { name: 'restore discard (.)', re: /\bgit\s+restore\s+(?:[^\s]+\s+)*\.\s*$/ },
+  { name: 'interactive rebase on protected branch', re: /\bgit\s+rebase\s+(?:[^\s]+\s+)*-i\b.*\b(main|master|trunk|release\/)/ },
+  { name: 'history rewrite (filter-branch)', re: /\bgit\s+filter-branch\b/ },
+  { name: 'reflog expire', re: /\bgit\s+reflog\s+expire\b/ },
+  { name: 'ref deletion', re: /\bgit\s+update-ref\s+-d\b/ },
+  { name: 'stash drop/clear', re: /\bgit\s+stash\s+(?:drop|clear)\b/ },
+];
+
+const WARN_NOT_BLOCK = [
+  { name: 'force-with-lease push', re: /\bgit\s+push\s+(?:[^\s]+\s+)*--force-with-lease\b/ },
+];
+
+function readStdin() {
+  return new Promise(resolve => {
+    let data = '';
+    process.stdin.on('data', c => { data += c; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+(async () => {
+  if (process.env.PRO_WORKFLOW_ALLOW_UNSAFE_GIT === '1') process.exit(0);
+  const raw = await readStdin();
+  let input = {};
+  try { input = JSON.parse(raw); } catch {}
+  const command = (input?.tool_input?.command || '').trim();
+  if (!command || !/^(?:.*\s)?git\s/.test(command)) process.exit(0);
+
+  for (const { name, re } of BLOCK) {
+    if (re.test(command)) {
+      console.error(`[pro-workflow] git-blast-radius: blocked "${name}". Command: ${command}`);
+      console.error(`Override for this shell: export PRO_WORKFLOW_ALLOW_UNSAFE_GIT=1`);
+      process.exit(2);
+    }
+  }
+  for (const { name, re } of WARN_NOT_BLOCK) {
+    if (re.test(command)) {
+      console.error(`[pro-workflow] git-blast-radius: caution — ${name} can still clobber remote refs. Proceeding.`);
+    }
+  }
+  process.exit(0);
+})();

--- a/scripts/secret-scan.js
+++ b/scripts/secret-scan.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+const PATTERNS = [
+  { name: 'AWS Access Key', re: /\bAKIA[0-9A-Z]{16}\b/ },
+  { name: 'AWS Secret Key', re: /\b(?:aws_)?secret(?:_access)?_key\s*[=:]\s*["']?[A-Za-z0-9/+=]{40}["']?/i },
+  { name: 'GitHub Token', re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/ },
+  { name: 'GitHub Fine-Grained Token', re: /\bgithub_pat_[A-Za-z0-9_]{82}\b/ },
+  { name: 'Anthropic API Key', re: /\bsk-ant-[A-Za-z0-9_\-]{20,}\b/ },
+  { name: 'OpenAI API Key', re: /\bsk-(?:proj-)?(?!ant-)[A-Za-z0-9_\-]{20,}\b/ },
+  { name: 'Slack Token', re: /\bxox[baprs]-[A-Za-z0-9\-]{10,}\b/ },
+  { name: 'Google API Key', re: /\bAIza[0-9A-Za-z_\-]{35}\b/ },
+  { name: 'Stripe Secret Key', re: /\bsk_live_[0-9a-zA-Z]{24,}\b/ },
+  { name: 'Private Key Block', re: /-----BEGIN (?:RSA |EC |DSA |OPENSSH |PGP )?PRIVATE KEY-----/ },
+  { name: 'Generic Bearer Token', re: /\bBearer\s+[A-Za-z0-9_\-.=]{30,}/ },
+  { name: 'Generic Password Assignment', re: /\b(?:password|passwd|pwd)\s*[=:]\s*["'][^"'\s]{8,}["']/i },
+  { name: 'Generic Secret Assignment', re: /\b(?:api[_\-]?key|api[_\-]?secret|secret|token)\s*[=:]\s*["'][A-Za-z0-9_\-]{20,}["']/i },
+];
+
+const ALLOWLIST = [
+  /example|placeholder|your[_\-]?(?:api[_\-]?)?key|xxx+|\*{4,}|<[A-Z_]+>/i,
+  /process\.env\./,
+  /os\.getenv|os\.environ/,
+];
+
+function readStdin() {
+  return new Promise(resolve => {
+    let data = '';
+    process.stdin.on('data', c => { data += c; });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', () => resolve(''));
+  });
+}
+
+function scan(content) {
+  if (!content) return null;
+  for (const { name, re } of PATTERNS) {
+    const m = content.match(re);
+    if (!m) continue;
+    const snippet = m[0];
+    if (ALLOWLIST.some(a => a.test(snippet))) continue;
+    const line = content.slice(0, m.index).split('\n').length;
+    return { name, snippet: snippet.slice(0, 40), line };
+  }
+  return null;
+}
+
+(async () => {
+  const raw = await readStdin();
+  let input = {};
+  try { input = JSON.parse(raw); } catch {}
+  const content = input?.tool_input?.content || input?.tool_input?.new_string || '';
+  const path = input?.tool_input?.file_path || '';
+  if (/\.(env|pem|key)$|\/secrets?\//i.test(path)) {
+    console.error(`[pro-workflow] secret-scan: refusing to write to secret-like path: ${path}`);
+    process.exit(2);
+  }
+  const hit = scan(content);
+  if (!hit) process.exit(0);
+  console.error(`[pro-workflow] secret-scan: detected ${hit.name} near line ${hit.line}: ${hit.snippet}... — remove or load from env.`);
+  process.exit(2);
+})();

--- a/scripts/secret-scan.js
+++ b/scripts/secret-scan.js
@@ -30,13 +30,20 @@ function readStdin() {
   });
 }
 
+function surroundingLine(content, index) {
+  const start = content.lastIndexOf('\n', index - 1) + 1;
+  const end = content.indexOf('\n', index);
+  return content.slice(start, end === -1 ? content.length : end);
+}
+
 function scan(content) {
   if (!content) return null;
   for (const { name, re } of PATTERNS) {
     const m = content.match(re);
     if (!m) continue;
     const snippet = m[0];
-    if (ALLOWLIST.some(a => a.test(snippet))) continue;
+    const context = surroundingLine(content, m.index);
+    if (ALLOWLIST.some(a => a.test(context))) continue;
     const line = content.slice(0, m.index).split('\n').length;
     return { name, snippet: snippet.slice(0, 40), line };
   }

--- a/skills/bug-capture/SKILL.md
+++ b/skills/bug-capture/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: bug-capture
+description: Capture a user-reported defect as a durable GitHub issue written in the project's own domain language. Explores the codebase in parallel for context but never leaks file paths or line numbers into the issue. Use when the user reports a bug conversationally, runs a QA pass, or says "file an issue", "log this as a bug", "capture this".
+---
+
+# bug-capture
+
+Turn a conversation into an issue that still reads correctly after a
+major refactor.
+
+## Flow
+
+### 1. Listen, then clarify minimally
+
+Let the user describe the problem in their own words. Ask at most two
+short clarifying questions, drawn from:
+
+- Expected behavior vs. actual behavior.
+- Concrete reproduction steps if not already implied.
+- Frequency: deterministic, intermittent, or one-off.
+
+If the description already answers these, skip straight to filing. Over-
+interviewing is a tax the reporter pays for your uncertainty.
+
+### 2. Explore in parallel
+
+While the user is answering, start a background exploration of the
+relevant area. The goal is **not** to propose a fix. The goal is to
+absorb the project's own vocabulary — the nouns and verbs the codebase
+uses for this feature — so the issue reads like it was written by a
+maintainer.
+
+If the repo has a glossary file (common names: GLOSSARY.md,
+UBIQUITOUS_LANGUAGE.md, docs/domain.md), read it first.
+
+### 3. Check for duplicates before filing
+
+Run `gh issue list --search "<key phrase>" --state all --limit 10`. If a
+live or recently closed issue matches, surface it to the user and ask
+whether to add a comment instead of opening a new issue. Do not silently
+skip filing.
+
+### 4. Decide: single issue or breakdown
+
+Break down when the report contains two or more independent failure
+modes that a different contributor could fix in parallel. Keep as one
+when every symptom traces to a single wrong behavior.
+
+For a breakdown, file in dependency order so each child issue can
+reference a real parent number, and mark honest `Blocked by` links.
+Avoid inventing dependencies to make the tree look tidier.
+
+### 5. File with `gh issue create`
+
+File without asking the user to review the draft. Send back the URLs.
+
+#### Single-issue template
+
+```
+## What happened
+<observed behavior, in domain terms>
+
+## What I expected
+<expected behavior>
+
+## Reproduction
+1. <step>
+2. <step>
+3. <step>
+
+## Context
+<anything that narrows where the bug lives, in domain terms — e.g.
+"only affects the import path, not the export path">
+```
+
+#### Child-issue template
+
+```
+## Parent
+#<parent-number>
+
+## What is wrong
+<one behavior, narrow slice>
+
+## What I expected
+<expected for this slice>
+
+## Reproduction
+1. <step>
+
+## Blocked by
+<#issue or "none — independent">
+
+## Context
+<notes that apply only to this slice>
+```
+
+### 6. Rules that apply to every issue body
+
+- No file paths, line numbers, function names, or PR numbers. These go
+  stale. Describe behavior, not code.
+- Use the project's domain nouns, not generic tech terms. "The sync
+  worker drops the patch" beats "`applyPatch()` throws".
+- Reproduction steps are mandatory. If you cannot derive them, go back
+  to the user once before filing.
+- Thirty-second read target. Cut anything that does not help a
+  maintainer decide whether to pick it up.
+
+### 7. Keep going
+
+After each issue, print the URL and ask whether there is a next one. Do
+not batch multiple reports into one filing pass — each bug deserves its
+own scoped issue.

--- a/skills/module-map/SKILL.md
+++ b/skills/module-map/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: module-map
+description: Produce a one-screen map of an unfamiliar area of the codebase: entry points, modules, data flow, callers. Designed to be read in fifteen seconds. Use when the user says "I do not know this area", "give me the map", "zoom out", "orient me".
+---
+
+# module-map
+
+Orient fast in unfamiliar code. The deliverable is a map, not a tour.
+
+## Deliverable
+
+A single response containing, in this order:
+
+1. **One-line summary** of what the area does from a caller's point of view.
+2. **Entry points** — every function, route, CLI command, event handler,
+   or cron that starts a call chain in this area. File path + symbol.
+3. **Core modules** — the two to five modules that contain the real
+   logic. One line each describing their role.
+4. **Data flow** — ASCII arrows showing the dominant path for the most
+   common input. Skip error paths unless they matter architecturally.
+5. **External callers** — who outside this area calls in, and through
+   which entry points.
+6. **Hidden coupling** — anything that looks independent but is not
+   (shared singletons, global state, implicit ordering, undocumented
+   contracts between files).
+
+## Rules
+
+- Fifteen-second read target. If the map exceeds one screen, cut it.
+- Every claim must be backed by a file path. No remembered or inferred
+  structure without a grep behind it.
+- Do not list every file. Curate. A good map omits deliberately.
+- Do not propose changes. Mapping is orientation; refactoring is a
+  different skill.
+- If the area is too large to map in one screen, segment it and ask the
+  user which segment to expand. Do not silently drop half the code.
+
+## Format
+
+```
+AREA: <one-line summary>
+
+ENTRY POINTS
+- <path>:<symbol>  — <role>
+
+CORE MODULES
+- <path>  — <role>
+
+FLOW
+<entry> -> <module> -> <module> -> <sink>
+
+CALLERS
+- <path>  — uses <entry>
+
+HIDDEN COUPLING
+- <description>  (<path>)
+```
+
+Use the exact headers. Consistency lets the user scan.

--- a/skills/plan-interrogate/SKILL.md
+++ b/skills/plan-interrogate/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: plan-interrogate
-description: Stress-test a plan or design by walking its decision tree one question at a time. Each question carries a recommended answer. Codebase exploration substitutes for asking whenever possible. Use when the user wants to pressure-test a design before implementation or says "interrogate the plan", "stress-test this", "walk the tree".
+description: Stress-test a plan by walking its decision tree one question at a time. Use when the user wants to pressure-test a design before implementation.
+user-invocable: true
 ---
 
 # plan-interrogate
@@ -13,19 +14,20 @@ before any code is written.
 1. Restate the plan in one paragraph. Confirm with the user that this is
    the plan being interrogated. Do not proceed on a mis-restatement.
 2. Extract the decision tree. Every branch point becomes a node. Mark
-   nodes as **open** (not decided), **pinned** (decided by the user), or
-   **inferred** (derivable from the codebase or existing constraints).
+   each node as **open** (undecided) or **resolved**. A resolved node
+   carries a source tag: `user` (the user answered), `inferred` (the
+   codebase or an existing constraint settled it).
 3. Resolve in dependency order. A node is ready when every node it
-   depends on is pinned or inferred.
+   depends on is resolved.
 4. For each ready open node, ask exactly one question. Keep the question
    tight and binary or small-multiple-choice when possible.
 5. Pair every question with a **recommended answer** and one sentence of
    reasoning. The user can confirm, pick a different option, or push back.
 6. Before asking, check whether the answer already lives in the codebase,
    prior commits, or an existing doc. If so, skip the question and mark
-   the node inferred with the source.
+   the node resolved with source `inferred: <path>`.
 7. Exit only when zero nodes are open. Print the resolved tree as a flat
-   list: "Decision — Choice — Source (user / inferred: path)".
+   list: `Decision — Choice — Source (user | inferred: <path>)`.
 
 ## Anti-patterns
 
@@ -41,5 +43,5 @@ before any code is written.
 ## Output contract
 
 A single decision ledger the user can paste into the plan doc. No prose
-summary. No hedging. If any node remains open because the user declined
-to decide, flag it as `DEFERRED` with the reason the user gave.
+summary. No hedging. If the user declines to decide a node, mark it
+`DEFERRED` with the reason the user gave — this is not the same as open.

--- a/skills/plan-interrogate/SKILL.md
+++ b/skills/plan-interrogate/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: plan-interrogate
+description: Stress-test a plan or design by walking its decision tree one question at a time. Each question carries a recommended answer. Codebase exploration substitutes for asking whenever possible. Use when the user wants to pressure-test a design before implementation or says "interrogate the plan", "stress-test this", "walk the tree".
+---
+
+# plan-interrogate
+
+Drive a plan from sketch to commitment by resolving every open decision
+before any code is written.
+
+## Method
+
+1. Restate the plan in one paragraph. Confirm with the user that this is
+   the plan being interrogated. Do not proceed on a mis-restatement.
+2. Extract the decision tree. Every branch point becomes a node. Mark
+   nodes as **open** (not decided), **pinned** (decided by the user), or
+   **inferred** (derivable from the codebase or existing constraints).
+3. Resolve in dependency order. A node is ready when every node it
+   depends on is pinned or inferred.
+4. For each ready open node, ask exactly one question. Keep the question
+   tight and binary or small-multiple-choice when possible.
+5. Pair every question with a **recommended answer** and one sentence of
+   reasoning. The user can confirm, pick a different option, or push back.
+6. Before asking, check whether the answer already lives in the codebase,
+   prior commits, or an existing doc. If so, skip the question and mark
+   the node inferred with the source.
+7. Exit only when zero nodes are open. Print the resolved tree as a flat
+   list: "Decision — Choice — Source (user / inferred: path)".
+
+## Anti-patterns
+
+- Asking multiple questions at once. The user loses context and you lose
+  the ability to react to each answer individually.
+- Asking before exploring. If a fifteen-second read would answer the
+  question, read first.
+- Asking without a recommendation. A question without a stance is a
+  survey; it offloads design onto the user.
+- Rolling past an unresolved node. If a dependency is not pinned, the
+  downstream question is premature.
+
+## Output contract
+
+A single decision ledger the user can paste into the plan doc. No prose
+summary. No hedging. If any node remains open because the user declined
+to decide, flag it as `DEFERRED` with the reason the user gave.


### PR DESCRIPTION
Fixes #47. Also adds defensive git hook, two design-discipline rules, and three new skills.

## Fix for #47 — deterministic hooks

`hooks/hooks.json` hardcoded `"model": "haiku"` for two prompt hooks, which no longer resolves in current Claude Code → hooks fired silently.

- `scripts/commit-validate.js` — regex conventional-commits validator. Parses `-m` flag and HEREDOC bodies, 11 allowed types, 72-char summary limit.
- `scripts/secret-scan.js` — regex patterns for AWS / GitHub (classic + fine-grained PAT) / OpenAI / Anthropic / Slack / Google / Stripe / PEM / Bearer / generic `password=` / `api_key=`. Allowlists `process.env.*`, placeholders, `<REDACTED>` style tokens. Refuses writes to `.env`, `.pem`, `.key`, `secrets/` paths.

`[LEARN]` capture is already a command-type hook (regex → SQLite); no change needed.

## New: `scripts/git-blast-radius.js`

PreToolUse Bash hook that blocks destructive git ops before execution. Patterns covered: force push, hard reset, `clean -f[d]`, `branch -D`, `checkout .` / `restore .`, interactive rebase on protected branches (main/master/trunk/release/*), `filter-branch`, `reflog expire`, `update-ref -d`, `stash drop|clear`.

- Warns (does not block) `push --force-with-lease`.
- Non-git commands pass through untouched.
- Escape hatch: `export PRO_WORKFLOW_ALLOW_UNSAFE_GIT=1` in the specific shell.

## New: design rules

- `rules/incremental-verify.mdc` — one test, one implementation, one commit. Guards against horizontal test authoring that asserts on imagined rather than observed behavior.
- `rules/module-shape.mdc` — narrow surface, thick depth. Inject dependencies at the boundary. Mock only at system edges. Endpoint-shaped mocks over generic fetchers.

## New skills

- `skills/plan-interrogate/` — walks a plan's decision tree one question at a time. Every question carries a recommended answer. Exits when zero open nodes remain.
- `skills/module-map/` — one-screen orientation map for unfamiliar areas. Entry points → core modules → data flow → callers → hidden coupling. Fifteen-second read target.
- `skills/bug-capture/` — durable GitHub issue capture. Minimal clarifying questions, parallel codebase exploration for domain language, `gh issue list --search` duplicate check, dependency-ordered breakdowns, no file paths or line numbers in issue bodies.

## Doctor updates

`commands/doctor.md` gains sanity-check commands for all three deterministic hook scripts, plus documentation for the git safety override.

## Test plan

- [x] `commit-validate.js` accepts `feat: x`, rejects `bad message` (exit 2)
- [x] `secret-scan.js` flags `sk-ant-*`, allows `api_key=process.env.FOO`
- [x] `git-blast-radius.js` blocks force push, hard reset, clean -fd, branch -D, checkout ., interactive rebase on main
- [x] `git-blast-radius.js` warns on --force-with-lease, allows safe `git push origin main`, passes through non-git commands
- [x] `PRO_WORKFLOW_ALLOW_UNSAFE_GIT=1` override works
- [x] `hooks.json` parses as valid JSON
- [ ] Manual: attempt a blocked git command with the plugin installed — hook blocks
- [ ] Manual: `/pro-workflow:doctor` prints the new sanity-check output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic command-based commit, secret and git-safety checks added, including an automated “git blast radius” safety check and a caution pathway.

* **Bug Fixes**
  * Commit message and secret validations now run deterministically with strict exit-status semantics (replacing prior interactive prompts).
  * Unsafe Git operations are detected and blocked by default; a documented per-shell override allows intentional bypass.

* **Documentation**
  * Added doctor guidance for deterministic hook sanity and git safety override.
  * New rules: Incremental Verification and Module Shape.
  * New skills: bug capture, module mapping, and plan interrogation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->