### PR TITLE
feat(skill-optimizer): SkillOpt-flavored offline training loop

### DIFF
--- a/commands/skill-optimize.md
+++ b/commands/skill-optimize.md
@@ -1,0 +1,37 @@
+---
+description: Train a skill's SKILL.md by running a SkillOpt-flavored offline loop over accumulated learn-rule corrections
+---
+
+# /skill-optimize - SkillOpt-flavored offline training
+
+Run an offline, budget-capped optimization loop over a skill's accumulated `learn-rule` trajectories. Proposes bounded patches via an optimizer LLM, validates each candidate against a held-out portion of the same trajectories, and overwrites SKILL.md only when the candidate strictly improves the weighted score.
+
+## Quick Start
+
+```
+/skill-optimize <slug> [--epochs 3] [--budget-usd 0.50]
+```
+
+## What it does
+
+1. Pulls recent `learnings` rows scoped to the skill slug (or global)
+2. Splits them into train + validation (~25% holdout, freezes validation set)
+3. Runs `epochs` x `minibatches` rounds of: reflect → aggregate → clip → apply → evaluate → gate
+4. Stops on: budget exhausted, kill switch (`~/.pro-workflow/STOP`), no improvement, or epochs done
+5. If any candidate beat the baseline, overwrites SKILL.md and stamps the new hash
+
+## Requirements
+
+- 8 or more existing `learnings` rows for the slug
+- `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / `OPENROUTER_API_KEY` / `FIREWORKS_API_KEY` with matching `--optimizer-provider`)
+- `npm run build` has been run in the pro-workflow plugin directory at least once
+
+## Examples
+
+```
+/skill-optimize pro-workflow
+/skill-optimize wiki-research-loop --budget-usd 1.0 --epochs 5
+/skill-optimize wrap-up --optimizer-model claude-opus-4-7 --evaluator-model gpt-4o-mini --json
+```
+
+See [skills/skill-optimizer/SKILL.md](../skills/skill-optimizer/SKILL.md) for full mechanics, defaults, and the SkillOpt provenance.

--- a/commands/skill-optimize.md
+++ b/commands/skill-optimize.md
@@ -8,7 +8,7 @@ Run an offline, budget-capped optimization loop over a skill's accumulated `lear
 
 ## Quick Start
 
-```
+```text
 /skill-optimize <slug> [--epochs 3] [--budget-usd 0.50]
 ```
 
@@ -28,10 +28,12 @@ Run an offline, budget-capped optimization loop over a skill's accumulated `lear
 
 ## Examples
 
-```
+```text
 /skill-optimize pro-workflow
 /skill-optimize wiki-research-loop --budget-usd 1.0 --epochs 5
-/skill-optimize wrap-up --optimizer-model claude-opus-4-7 --evaluator-model gpt-4o-mini --json
+/skill-optimize wrap-up --optimizer-model claude-opus-4-7 --evaluator-model gpt-4o-mini
 ```
+
+The third example mixes providers. The CLI infers the provider from the model id (`claude-*` → anthropic, `gpt-*` / `o*` → openai), so you do not need `--evaluator-provider openai` for `gpt-4o-mini`. Pass an explicit `--optimizer-provider` / `--evaluator-provider` to override inference.
 
 See [skills/skill-optimizer/SKILL.md](../skills/skill-optimizer/SKILL.md) for full mechanics, defaults, and the SkillOpt provenance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,10 +14,453 @@
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.12",
         "@types/node": "^25.2.2",
+        "tsx": "^4.20.0",
         "typescript": "^6.0.2"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@types/better-sqlite3": {
@@ -166,6 +609,48 @@
         "once": "^1.4.0"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
     "node_modules/expand-template": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
@@ -186,6 +671,21 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "license": "MIT"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/github-from-package": {
       "version": "0.0.0",
@@ -465,6 +965,25 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
       }
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pro-workflow",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Complete AI coding workflow system with orchestration patterns, cross-agent support, reference guides, searchable learnings, and persistent research wikis",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -8,7 +8,8 @@
     "build": "tsc && node -e \"const fs=require('fs');fs.mkdirSync('dist/db',{recursive:true});fs.copyFileSync('src/db/schema.sql','dist/db/schema.sql')\"",
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build",
-    "db:init": "node dist/db/index.js"
+    "db:init": "node dist/db/index.js",
+    "test": "tsx --test src/optimizer/__tests__/*.test.ts"
   },
   "keywords": [
     "claude-code",
@@ -47,6 +48,7 @@
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.12",
     "@types/node": "^25.2.2",
+    "tsx": "^4.20.0",
     "typescript": "^6.0.2"
   },
   "files": [

--- a/scripts/optimize-skill.js
+++ b/scripts/optimize-skill.js
@@ -35,11 +35,31 @@ function parseArgs(argv) {
     if (!a.startsWith('--')) continue;
     const key = a.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
     const v = argv[++i];
-    if (intKeys.has(key)) out[key] = parseInt(v, 10);
-    else if (floatKeys.has(key)) out[key] = parseFloat(v);
-    else out[key] = v;
+    if (v === undefined || v === '') {
+      throw new Error(`Missing value for --${key}`);
+    }
+    if (intKeys.has(key)) {
+      const parsed = parseInt(v, 10);
+      if (!Number.isFinite(parsed)) throw new Error(`Invalid integer value for --${key}: ${v}`);
+      out[key] = parsed;
+    } else if (floatKeys.has(key)) {
+      const parsed = parseFloat(v);
+      if (!Number.isFinite(parsed)) throw new Error(`Invalid number value for --${key}: ${v}`);
+      out[key] = parsed;
+    } else {
+      out[key] = v;
+    }
   }
   return out;
+}
+
+function inferProvider(model) {
+  if (!model) return null;
+  if (/^claude-/.test(model)) return 'anthropic';
+  if (/^(gpt-|o\d|chatgpt-)/i.test(model) || /openai/i.test(model)) return 'openai';
+  if (/(?:^|\/)(?:llama-|mistralai\/|accounts\/fireworks)/i.test(model)) return 'fireworks';
+  if (/\//.test(model)) return 'openrouter';
+  return null;
 }
 
 function findSkillPath(slug) {
@@ -52,10 +72,26 @@ function findSkillPath(slug) {
 }
 
 (async () => {
-  const args = parseArgs(process.argv);
+  let args;
+  try {
+    args = parseArgs(process.argv);
+  } catch (err) {
+    process.stderr.write(`${err.message}\n`);
+    process.exit(1);
+  }
   if (!args.slug) {
     process.stderr.write('Usage: optimize-skill --slug <name> [--skill-path <path>] [options]\n');
     process.exit(1);
+  }
+  const userSetOptProvider = process.argv.includes('--optimizer-provider');
+  const userSetEvalProvider = process.argv.includes('--evaluator-provider');
+  if (!userSetOptProvider) {
+    const inferred = inferProvider(args.optimizerModel);
+    if (inferred) args.optimizerProvider = inferred;
+  }
+  if (!userSetEvalProvider) {
+    const inferred = inferProvider(args.evaluatorModel);
+    if (inferred) args.evaluatorProvider = inferred;
   }
   const skillPath = args.skillPath || findSkillPath(args.slug);
   if (!skillPath || !fs.existsSync(skillPath)) {

--- a/scripts/optimize-skill.js
+++ b/scripts/optimize-skill.js
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function parseArgs(argv) {
+  const out = {
+    slug: null,
+    skillPath: null,
+    epochs: 3,
+    batchSize: 8,
+    minibatches: 2,
+    holdout: 6,
+    budgetUsd: 0.5,
+    optimizerModel: 'claude-sonnet-4-6',
+    optimizerProvider: 'anthropic',
+    evaluatorModel: 'claude-haiku-4-5-20251001',
+    evaluatorProvider: 'anthropic',
+    slowEvery: 2,
+    metaEvery: 5,
+    acceptThreshold: 0.0,
+    maxSkillTokens: 2000,
+    maxAdds: 3,
+    maxDeletes: 2,
+    maxReplaces: 3,
+    json: false,
+  };
+  const intKeys = new Set(['epochs', 'batchSize', 'minibatches', 'holdout', 'slowEvery', 'metaEvery', 'maxSkillTokens', 'maxAdds', 'maxDeletes', 'maxReplaces']);
+  const floatKeys = new Set(['budgetUsd', 'acceptThreshold']);
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') { out.json = true; continue; }
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2).replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+    const v = argv[++i];
+    if (intKeys.has(key)) out[key] = parseInt(v, 10);
+    else if (floatKeys.has(key)) out[key] = parseFloat(v);
+    else out[key] = v;
+  }
+  return out;
+}
+
+function findSkillPath(slug) {
+  const candidates = [
+    path.join(ROOT, 'skills', slug, 'SKILL.md'),
+    path.join(os.homedir(), '.claude', 'skills', slug, 'SKILL.md'),
+  ];
+  for (const c of candidates) if (fs.existsSync(c)) return c;
+  return null;
+}
+
+(async () => {
+  const args = parseArgs(process.argv);
+  if (!args.slug) {
+    process.stderr.write('Usage: optimize-skill --slug <name> [--skill-path <path>] [options]\n');
+    process.exit(1);
+  }
+  const skillPath = args.skillPath || findSkillPath(args.slug);
+  if (!skillPath || !fs.existsSync(skillPath)) {
+    process.stderr.write(`SKILL.md not found for slug "${args.slug}"\n`);
+    process.exit(1);
+  }
+
+  const distPath = path.join(ROOT, 'dist', 'optimizer', 'trainer.js');
+  if (!fs.existsSync(distPath)) {
+    process.stderr.write(`Run 'npm run build' first; compiled trainer missing at ${distPath}\n`);
+    process.exit(1);
+  }
+  const { train } = require(distPath);
+
+  const killSwitchPath = path.join(os.homedir(), '.pro-workflow', 'STOP');
+  const config = {
+    epochs: args.epochs,
+    batchSize: args.batchSize,
+    minibatches: args.minibatches,
+    lrBudget: { maxAdds: args.maxAdds, maxDeletes: args.maxDeletes, maxReplaces: args.maxReplaces },
+    validationHoldout: args.holdout,
+    budgetUsd: args.budgetUsd,
+    optimizerModel: args.optimizerModel,
+    optimizerProvider: args.optimizerProvider,
+    evaluatorModel: args.evaluatorModel,
+    evaluatorProvider: args.evaluatorProvider,
+    slowUpdateEveryEpochs: args.slowEvery,
+    metaUpdateEveryEpochs: args.metaEvery,
+    acceptThreshold: args.acceptThreshold,
+    maxSkillTokens: args.maxSkillTokens,
+    killSwitchPath,
+  };
+
+  try {
+    const outcome = await train({
+      skillSlug: args.slug,
+      skillPath,
+      config,
+      logger: args.json ? () => {} : (line) => process.stderr.write(`[skill-optimizer] ${line}\n`),
+    });
+    if (args.json) {
+      process.stdout.write(JSON.stringify({
+        runId: outcome.runId,
+        skillPath,
+        initialScore: outcome.initialScore,
+        bestScore: outcome.bestScore,
+        delta: outcome.bestScore - outcome.initialScore,
+        epochsCompleted: outcome.epochsCompleted,
+        acceptedSteps: outcome.acceptedSteps,
+        rejectedSteps: outcome.rejectedSteps,
+        spentUsd: outcome.spentUsd,
+        bestSkillHash: outcome.bestSkillHash,
+        stoppedReason: outcome.stoppedReason,
+      }) + '\n');
+    } else {
+      process.stdout.write(`Done. score ${outcome.initialScore.toFixed(3)} -> ${outcome.bestScore.toFixed(3)} ` +
+        `(${outcome.acceptedSteps} accepted, ${outcome.rejectedSteps} rejected, $${outcome.spentUsd.toFixed(3)}).\n`);
+    }
+    process.exit(0);
+  } catch (err) {
+    if (args.json) process.stdout.write(JSON.stringify({ error: String(err.message || err) }) + '\n');
+    else process.stderr.write(`Error: ${err.message || err}\n`);
+    process.exit(2);
+  }
+})();

--- a/skills/skill-optimizer/SKILL.md
+++ b/skills/skill-optimizer/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: skill-optimizer
+description: SkillOpt-flavored offline training loop for any SKILL.md. Treats accumulated learn-rule corrections as training trajectories, proposes bounded patches via an optimizer LLM, gates each candidate against a held-out validation set built from the user's own past corrections, and ships only candidates that demonstrably improve the score. Inspired by Microsoft SkillOpt's ReflACT pipeline (rollout → reflect → aggregate → select → update → evaluate) adapted to pro-workflow's SQLite store. Use when a skill has accumulated 8+ learn-rule rows and the user wants the skill itself to get better, not just longer.
+---
+
+# Skill Optimizer
+
+Train an existing SKILL.md the way a deep-learning optimizer trains weights: via rollouts, gradient-like reflections, validation-gated acceptance. No model retraining; only the skill markdown changes.
+
+## When to use
+
+Use this skill when:
+- A pro-workflow skill has accumulated 8+ learn-rule rows for it
+- The user reports the skill is "getting bloated" or "rules keep being repeated"
+- The user wants offline, budget-capped improvement over multiple sessions
+
+Do not use when:
+- Skill has fewer than 8 trajectories (nothing to learn from)
+- The user wants real-time edits (this is offline, single-shot)
+- No `ANTHROPIC_API_KEY` (or equivalent provider key) is available
+
+## Architecture (mirrors SkillOpt)
+
+```
+rollout      — pull recent learnings from SQLite (existing learn-rule rows)
+reflect      — optimizer LLM analyzes a minibatch, proposes add/delete/replace patches
+aggregate    — vote-merge patches across minibatches
+select       — clip by LR budget (default: 3 adds, 2 deletes, 3 replaces per step)
+update       — apply selected patches to a candidate skill content
+evaluate     — evaluator LLM scores candidate against held-out validation items
+gate         — accept candidate only if weighted score >= current + acceptThreshold
+slow update  — at epoch boundary, consolidate accepted edits into a coherent rewrite
+```
+
+Failed candidates are stored in a rejection buffer and fed back to the next reflect step so the optimizer doesn't propose the same patch twice.
+
+## Run it
+
+```bash
+/skill-optimize <slug> [options]
+```
+
+Options (all optional; sensible defaults shown):
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--epochs N` | 3 | Outer loop count |
+| `--batch-size N` | 8 | Trajectories per minibatch |
+| `--minibatches N` | 2 | Minibatches per epoch |
+| `--holdout N` | 6 | Validation items reserved (max ~25% of trajectories) |
+| `--budget-usd X` | 0.50 | Hard cap; loop aborts when spent |
+| `--optimizer-model M` | `claude-sonnet-4-6` | Reflect + slow-update model |
+| `--evaluator-model M` | `claude-haiku-4-5-20251001` | Gate model (cheaper) |
+| `--max-adds N` | 3 | LR budget per step |
+| `--max-deletes N` | 2 | |
+| `--max-replaces N` | 3 | |
+| `--accept-threshold X` | 0.0 | Minimum score delta to accept candidate |
+| `--max-skill-tokens N` | 2000 | Hard cap on candidate length |
+| `--slow-every N` | 2 | Epochs between consolidation passes |
+| `--json` | off | Machine-readable output |
+
+Kill switch: `touch ~/.pro-workflow/STOP` aborts the loop between steps.
+
+## Output
+
+- Candidate accepted → SKILL.md overwritten, hash stamp appended in HTML comment
+- Run details persist in `optimization_runs`, `optimization_candidates`, `optimization_patches`, `optimization_rejections`
+- Validation set persists in `optimization_validation` (reusable across runs)
+
+Inspect after:
+
+```bash
+sqlite3 ~/.pro-workflow/data.db "SELECT id, skill_slug, initial_score, best_score, accepted_steps, rejected_steps, spent_usd FROM optimization_runs ORDER BY id DESC LIMIT 5"
+```
+
+## Rules
+
+- Validation set is frozen at run start. Never re-derive from new corrections mid-run.
+- One candidate per step. No parallel branches.
+- Slow-update output is itself a candidate; it must pass the gate to replace the best.
+- The optimizer LLM and evaluator LLM may be different models. Mixing a strong optimizer with a cheap evaluator is the SkillOpt-recommended config.
+- If `spent_usd >= budget_usd` at any step boundary, the loop ends with `stopped_reason="budget exhausted"`.
+- Patches whose anchor is no longer present in the skill (because a prior patch in the same step removed it) are recorded as rejected with reason `anchor_missing`.
+
+## Provenance
+
+Inspired by Microsoft SkillOpt (arXiv:2605.23904). The ReflACT 6-stage pipeline, LR budget, rejection buffer, and slow / meta update mechanics are adapted to pro-workflow's existing SQLite + learn-rule data plane. No SkillOpt code is reused.

--- a/skills/skill-optimizer/SKILL.md
+++ b/skills/skill-optimizer/SKILL.md
@@ -19,17 +19,17 @@ Do not use when:
 - The user wants real-time edits (this is offline, single-shot)
 - No `ANTHROPIC_API_KEY` (or equivalent provider key) is available
 
-## Architecture (mirrors SkillOpt)
+## Architecture (mirrors SkillOpt's six-stage loop)
 
-```
-rollout      — pull recent learnings from SQLite (existing learn-rule rows)
-reflect      — optimizer LLM analyzes a minibatch, proposes add/delete/replace patches
-aggregate    — vote-merge patches across minibatches
-select       — clip by LR budget (default: 3 adds, 2 deletes, 3 replaces per step)
-update       — apply selected patches to a candidate skill content
-evaluate     — evaluator LLM scores candidate against held-out validation items
-gate         — accept candidate only if weighted score >= current + acceptThreshold
-slow update  — at epoch boundary, consolidate accepted edits into a coherent rewrite
+```text
+rollout      pull recent learnings from SQLite (existing learn-rule rows)
+reflect      optimizer LLM analyzes a minibatch, proposes add/delete/replace patches
+aggregate    vote-merge patches across minibatches
+select       clip by LR budget (default: 3 adds, 2 deletes, 3 replaces per step)
+update       apply selected patches to a candidate skill content
+evaluate     evaluator LLM scores candidate against held-out validation items
+gate         accept candidate only if weighted score >= current + acceptThreshold
+slow update  at epoch boundary, consolidate accepted edits into a coherent rewrite
 ```
 
 Failed candidates are stored in a rejection buffer and fed back to the next reflect step so the optimizer doesn't propose the same patch twice.
@@ -84,4 +84,4 @@ sqlite3 ~/.pro-workflow/data.db "SELECT id, skill_slug, initial_score, best_scor
 
 ## Provenance
 
-Inspired by Microsoft SkillOpt (arXiv:2605.23904). The ReflACT 6-stage pipeline, LR budget, rejection buffer, and slow / meta update mechanics are adapted to pro-workflow's existing SQLite + learn-rule data plane. No SkillOpt code is reused.
+Inspired by Microsoft SkillOpt (arXiv:2605.23904). The six-stage rollout/reflect/aggregate/select/update/evaluate pipeline, LR budget, rejection buffer, and slow / meta update mechanics are adapted to pro-workflow's existing SQLite + learn-rule data plane. No SkillOpt code is reused. "ReflACT" is not a SkillOpt term and is not used here; the loop is referred to by stage names only.

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -166,3 +166,86 @@ CREATE TABLE IF NOT EXISTS learnings_wiki (
   wiki_slug TEXT NOT NULL REFERENCES wikis(slug) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS idx_learnings_wiki_slug ON learnings_wiki(wiki_slug);
+
+-- Skill optimizer (Phase 3.4). SkillOpt-flavored offline training loop for skill markdown.
+-- Treats SKILL.md as trainable text-space state, learn-rule rows as training trajectories,
+-- and held-out corrections as the validation set. Mirrors the 6-stage ReflACT pipeline:
+-- rollout (existing learnings) -> reflect (LLM patches) -> aggregate -> select/clip ->
+-- update (apply) -> evaluate (gate). All LLM calls are batched and budget-capped.
+
+CREATE TABLE IF NOT EXISTS optimization_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  skill_slug TEXT NOT NULL,
+  started_at TEXT DEFAULT (datetime('now')),
+  ended_at TEXT,
+  status TEXT NOT NULL DEFAULT 'running',
+  initial_skill_hash TEXT NOT NULL,
+  best_skill_hash TEXT,
+  initial_score REAL,
+  best_score REAL,
+  epochs_completed INTEGER DEFAULT 0,
+  accepted_steps INTEGER DEFAULT 0,
+  rejected_steps INTEGER DEFAULT 0,
+  budget_usd REAL,
+  spent_usd REAL DEFAULT 0,
+  config_json TEXT,
+  reason TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_opt_runs_skill ON optimization_runs(skill_slug);
+CREATE INDEX IF NOT EXISTS idx_opt_runs_status ON optimization_runs(status);
+
+CREATE TABLE IF NOT EXISTS optimization_candidates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER NOT NULL REFERENCES optimization_runs(id) ON DELETE CASCADE,
+  parent_hash TEXT NOT NULL,
+  content_hash TEXT NOT NULL,
+  content TEXT NOT NULL,
+  source_patches_json TEXT,
+  step INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
+  score REAL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at TEXT DEFAULT (datetime('now')),
+  evaluated_at TEXT,
+  UNIQUE(run_id, content_hash)
+);
+CREATE INDEX IF NOT EXISTS idx_opt_cand_run ON optimization_candidates(run_id);
+CREATE INDEX IF NOT EXISTS idx_opt_cand_status ON optimization_candidates(status);
+
+CREATE TABLE IF NOT EXISTS optimization_patches (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER NOT NULL REFERENCES optimization_runs(id) ON DELETE CASCADE,
+  candidate_id INTEGER REFERENCES optimization_candidates(id) ON DELETE SET NULL,
+  step INTEGER NOT NULL,
+  epoch INTEGER NOT NULL,
+  op TEXT NOT NULL,
+  anchor TEXT,
+  payload TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'proposed',
+  rejected_reason TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_opt_patches_run ON optimization_patches(run_id);
+CREATE INDEX IF NOT EXISTS idx_opt_patches_status ON optimization_patches(status);
+
+CREATE TABLE IF NOT EXISTS optimization_validation (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  skill_slug TEXT NOT NULL,
+  learning_id INTEGER REFERENCES learnings(id) ON DELETE SET NULL,
+  prompt TEXT NOT NULL,
+  expected TEXT NOT NULL,
+  weight REAL NOT NULL DEFAULT 1.0,
+  frozen_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_opt_val_skill ON optimization_validation(skill_slug);
+
+CREATE TABLE IF NOT EXISTS optimization_rejections (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_id INTEGER NOT NULL REFERENCES optimization_runs(id) ON DELETE CASCADE,
+  candidate_hash TEXT NOT NULL,
+  patches_json TEXT NOT NULL,
+  reason TEXT NOT NULL,
+  delta_score REAL,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_opt_rej_run ON optimization_rejections(run_id);

--- a/src/db/schema.sql
+++ b/src/db/schema.sql
@@ -232,12 +232,14 @@ CREATE TABLE IF NOT EXISTS optimization_validation (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   skill_slug TEXT NOT NULL,
   learning_id INTEGER REFERENCES learnings(id) ON DELETE SET NULL,
+  prompt_hash TEXT NOT NULL,
   prompt TEXT NOT NULL,
   expected TEXT NOT NULL,
   weight REAL NOT NULL DEFAULT 1.0,
   frozen_at TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_opt_val_skill ON optimization_validation(skill_slug);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_opt_val_unique ON optimization_validation(skill_slug, prompt_hash);
 
 CREATE TABLE IF NOT EXISTS optimization_rejections (
   id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/src/optimizer/__tests__/apply.test.ts
+++ b/src/optimizer/__tests__/apply.test.ts
@@ -1,0 +1,92 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { applyPatches } from '../apply';
+import { aggregatePatches } from '../aggregate';
+import { clipByLR } from '../clip';
+import type { Patch } from '../types';
+
+describe('applyPatches', () => {
+  it('appends "add" without anchor at end', () => {
+    const out = applyPatches('# Skill\n\n- rule 1\n', [
+      { op: 'add', anchor: '', payload: '- rule 2' },
+    ]);
+    assert.equal(out.applied.length, 1);
+    assert.match(out.content, /- rule 2\n$/);
+  });
+
+  it('inserts "add" after anchor', () => {
+    const out = applyPatches('# Skill\n\n## Rules\n- existing\n', [
+      { op: 'add', anchor: '## Rules', payload: '- new-rule' },
+    ]);
+    assert.match(out.content, /## Rules\n\n- new-rule\n- existing/);
+  });
+
+  it('"delete" removes anchor block', () => {
+    const out = applyPatches('# A\n\n- bad rule\n\n- good rule\n', [
+      { op: 'delete', anchor: '- bad rule\n', payload: '' },
+    ]);
+    assert.equal(out.applied.length, 1);
+    assert.doesNotMatch(out.content, /bad rule/);
+    assert.match(out.content, /good rule/);
+  });
+
+  it('"replace" swaps anchor for payload', () => {
+    const out = applyPatches('# Skill\n- old phrasing\n', [
+      { op: 'replace', anchor: 'old phrasing', payload: 'new phrasing' },
+    ]);
+    assert.match(out.content, /new phrasing/);
+  });
+
+  it('skips patches whose anchor is missing', () => {
+    const out = applyPatches('# Skill\n', [
+      { op: 'replace', anchor: 'nonexistent', payload: 'x' },
+    ]);
+    assert.equal(out.applied.length, 0);
+    assert.equal(out.skipped.length, 1);
+    assert.match(out.skipped[0].reason, /anchor not found/);
+  });
+});
+
+describe('aggregatePatches', () => {
+  it('merges identical patches and counts votes', () => {
+    const a: Patch = { op: 'add', anchor: '## X', payload: '- foo' };
+    const out = aggregatePatches([[a], [a], [a]]);
+    assert.equal(out.merged.length, 1);
+    assert.equal(out.duplicates, 2);
+  });
+
+  it('detects conflicts on same anchor different payload', () => {
+    const out = aggregatePatches([
+      [{ op: 'replace', anchor: '## X', payload: 'A' }],
+      [{ op: 'replace', anchor: '## X', payload: 'B' }],
+    ]);
+    assert.ok(out.conflicts >= 1);
+  });
+
+  it('orders deletes before replaces before adds', () => {
+    const out = aggregatePatches([
+      [{ op: 'add', anchor: 'a', payload: '1' }],
+      [{ op: 'delete', anchor: 'b', payload: '' }],
+      [{ op: 'replace', anchor: 'c', payload: '2' }],
+    ]);
+    assert.equal(out.merged[0].op, 'delete');
+    assert.equal(out.merged[1].op, 'replace');
+    assert.equal(out.merged[2].op, 'add');
+  });
+});
+
+describe('clipByLR', () => {
+  it('respects per-op budget', () => {
+    const patches: Patch[] = [
+      { op: 'add', anchor: 'a', payload: '1' },
+      { op: 'add', anchor: 'b', payload: '2' },
+      { op: 'add', anchor: 'c', payload: '3' },
+      { op: 'delete', anchor: 'x', payload: '' },
+      { op: 'replace', anchor: 'y', payload: 'z' },
+    ];
+    const out = clipByLR(patches, { maxAdds: 2, maxDeletes: 1, maxReplaces: 1 });
+    assert.equal(out.selected.filter((p) => p.op === 'add').length, 2);
+    assert.equal(out.clipped.filter((p) => p.op === 'add').length, 1);
+    assert.equal(out.selected.length, 4);
+  });
+});

--- a/src/optimizer/__tests__/apply.test.ts
+++ b/src/optimizer/__tests__/apply.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { applyPatches } from '../apply';
 import { aggregatePatches } from '../aggregate';
 import { clipByLR } from '../clip';
+import { stripExistingStamp } from '../trainer';
 import type { Patch } from '../types';
 
 describe('applyPatches', () => {
@@ -72,6 +73,38 @@ describe('aggregatePatches', () => {
     assert.equal(out.merged[0].op, 'delete');
     assert.equal(out.merged[1].op, 'replace');
     assert.equal(out.merged[2].op, 'add');
+  });
+});
+
+describe('apply replace handles $-sequences verbatim', () => {
+  it('does not treat $1 in payload as a backreference', () => {
+    const out = applyPatches('# A\nold\n', [
+      { op: 'replace', anchor: 'old', payload: 'cost: $1 per unit, $2 each' },
+    ]);
+    assert.match(out.content, /cost: \$1 per unit, \$2 each/);
+  });
+});
+
+describe('aggregate keeps distinct payloads at same anchor', () => {
+  it('does not collide different add payloads at same anchor', () => {
+    const out = aggregatePatches([
+      [{ op: 'add', anchor: '## X', payload: 'foo' }],
+      [{ op: 'add', anchor: '## X', payload: 'bar' }],
+    ]);
+    assert.equal(out.merged.length, 2);
+    assert.ok(out.conflicts >= 1);
+  });
+});
+
+describe('stripExistingStamp', () => {
+  it('removes the trailing optimizer stamp', () => {
+    const stamped = '# Skill\nbody\n<!-- skill-optimizer: hash=abc slug=foo -->\n';
+    assert.equal(stripExistingStamp(stamped), '# Skill\nbody');
+  });
+
+  it('leaves unstamped content alone', () => {
+    const plain = '# Skill\nbody\n';
+    assert.equal(stripExistingStamp(plain), plain);
   });
 });
 

--- a/src/optimizer/__tests__/apply.test.ts
+++ b/src/optimizer/__tests__/apply.test.ts
@@ -99,12 +99,17 @@ describe('aggregate keeps distinct payloads at same anchor', () => {
 describe('stripExistingStamp', () => {
   it('removes the trailing optimizer stamp', () => {
     const stamped = '# Skill\nbody\n<!-- skill-optimizer: hash=abc slug=foo -->\n';
-    assert.equal(stripExistingStamp(stamped), '# Skill\nbody');
+    assert.equal(stripExistingStamp(stamped).trimEnd(), '# Skill\nbody');
   });
 
   it('leaves unstamped content alone', () => {
     const plain = '# Skill\nbody\n';
     assert.equal(stripExistingStamp(plain), plain);
+  });
+
+  it('removes multiple accumulated stamps', () => {
+    const doubled = '# Skill\nbody\n<!-- skill-optimizer: hash=abc slug=foo -->\n<!-- skill-optimizer: hash=def slug=foo -->\n';
+    assert.equal(stripExistingStamp(doubled).trimEnd(), '# Skill\nbody');
   });
 });
 

--- a/src/optimizer/aggregate.ts
+++ b/src/optimizer/aggregate.ts
@@ -8,23 +8,27 @@ export interface AggregateResult {
 
 export function aggregatePatches(batches: Patch[][]): AggregateResult {
   const seen = new Map<string, { patch: Patch; votes: number }>();
-  let conflicts = 0;
+  const anchorSeen = new Map<string, Set<string>>();
 
   for (const batch of batches) {
     for (const patch of batch) {
       const key = patchKey(patch);
       const prior = seen.get(key);
-      if (!prior) {
-        seen.set(key, { patch, votes: 1 });
-        continue;
-      }
-      if (prior.patch.op === patch.op && prior.patch.payload === patch.payload) {
+      if (prior) {
         prior.votes++;
       } else {
-        conflicts++;
-        if (prior.votes < 2) seen.set(key, { patch, votes: 1 });
+        seen.set(key, { patch, votes: 1 });
       }
+      const anchorKey = anchorKeyFor(patch);
+      const set = anchorSeen.get(anchorKey) ?? new Set<string>();
+      set.add(patch.payload);
+      anchorSeen.set(anchorKey, set);
     }
+  }
+
+  let conflicts = 0;
+  for (const variants of anchorSeen.values()) {
+    if (variants.size > 1) conflicts += variants.size - 1;
   }
 
   const ordered = [...seen.values()].sort((a, b) => {
@@ -37,6 +41,10 @@ export function aggregatePatches(batches: Patch[][]): AggregateResult {
 }
 
 function patchKey(p: Patch): string {
+  return `${p.op}::${p.anchor.trim().toLowerCase()}::${p.payload}`;
+}
+
+function anchorKeyFor(p: Patch): string {
   return `${p.op}::${p.anchor.trim().toLowerCase()}`;
 }
 

--- a/src/optimizer/aggregate.ts
+++ b/src/optimizer/aggregate.ts
@@ -1,0 +1,47 @@
+import type { Patch } from './types';
+
+export interface AggregateResult {
+  merged: Patch[];
+  duplicates: number;
+  conflicts: number;
+}
+
+export function aggregatePatches(batches: Patch[][]): AggregateResult {
+  const seen = new Map<string, { patch: Patch; votes: number }>();
+  let conflicts = 0;
+
+  for (const batch of batches) {
+    for (const patch of batch) {
+      const key = patchKey(patch);
+      const prior = seen.get(key);
+      if (!prior) {
+        seen.set(key, { patch, votes: 1 });
+        continue;
+      }
+      if (prior.patch.op === patch.op && prior.patch.payload === patch.payload) {
+        prior.votes++;
+      } else {
+        conflicts++;
+        if (prior.votes < 2) seen.set(key, { patch, votes: 1 });
+      }
+    }
+  }
+
+  const ordered = [...seen.values()].sort((a, b) => {
+    if (a.patch.op !== b.patch.op) return opRank(a.patch.op) - opRank(b.patch.op);
+    return b.votes - a.votes;
+  });
+
+  const duplicates = ordered.reduce((acc, e) => acc + Math.max(0, e.votes - 1), 0);
+  return { merged: ordered.map((e) => e.patch), duplicates, conflicts };
+}
+
+function patchKey(p: Patch): string {
+  return `${p.op}::${p.anchor.trim().toLowerCase()}`;
+}
+
+function opRank(op: Patch['op']): number {
+  if (op === 'delete') return 0;
+  if (op === 'replace') return 1;
+  return 2;
+}

--- a/src/optimizer/apply.ts
+++ b/src/optimizer/apply.ts
@@ -1,0 +1,69 @@
+import type { Patch } from './types';
+
+export interface ApplyResult {
+  content: string;
+  applied: Patch[];
+  skipped: Array<{ patch: Patch; reason: string }>;
+}
+
+export function applyPatches(skill: string, patches: Patch[]): ApplyResult {
+  let content = skill;
+  const applied: Patch[] = [];
+  const skipped: Array<{ patch: Patch; reason: string }> = [];
+
+  for (const patch of patches) {
+    const next = applyOne(content, patch);
+    if (next.ok) {
+      content = next.content;
+      applied.push(patch);
+    } else {
+      skipped.push({ patch, reason: next.reason });
+    }
+  }
+
+  return { content, applied, skipped };
+}
+
+function applyOne(skill: string, patch: Patch): { ok: true; content: string } | { ok: false; reason: string } {
+  if (patch.op === 'add') {
+    if (!patch.anchor) {
+      return { ok: true, content: skill.replace(/\s*$/, '\n\n') + patch.payload.replace(/\s*$/, '') + '\n' };
+    }
+    if (!skill.includes(patch.anchor)) {
+      return { ok: false, reason: `anchor not found: ${truncate(patch.anchor)}` };
+    }
+    const insertAt = skill.indexOf(patch.anchor) + patch.anchor.length;
+    const before = skill.slice(0, insertAt);
+    const after = skill.slice(insertAt).replace(/^\n+/, '');
+    const payload = patch.payload.replace(/\s+$/, '');
+    return { ok: true, content: `${before}\n\n${payload}\n${after}` };
+  }
+
+  if (patch.op === 'delete') {
+    if (!patch.anchor) return { ok: false, reason: 'delete requires anchor' };
+    if (!skill.includes(patch.anchor)) {
+      return { ok: false, reason: `anchor not found: ${truncate(patch.anchor)}` };
+    }
+    const before = skill.indexOf(patch.anchor);
+    const after = before + patch.anchor.length;
+    return { ok: true, content: collapseBlankLines(skill.slice(0, before) + skill.slice(after)) };
+  }
+
+  if (patch.op === 'replace') {
+    if (!patch.anchor) return { ok: false, reason: 'replace requires anchor' };
+    if (!skill.includes(patch.anchor)) {
+      return { ok: false, reason: `anchor not found: ${truncate(patch.anchor)}` };
+    }
+    return { ok: true, content: skill.replace(patch.anchor, patch.payload) };
+  }
+
+  return { ok: false, reason: `unknown op: ${(patch as Patch).op}` };
+}
+
+function truncate(s: string, n = 60): string {
+  return s.length <= n ? s : s.slice(0, n) + '...';
+}
+
+function collapseBlankLines(s: string): string {
+  return s.replace(/\n{3,}/g, '\n\n');
+}

--- a/src/optimizer/apply.ts
+++ b/src/optimizer/apply.ts
@@ -54,7 +54,7 @@ function applyOne(skill: string, patch: Patch): { ok: true; content: string } | 
     if (!skill.includes(patch.anchor)) {
       return { ok: false, reason: `anchor not found: ${truncate(patch.anchor)}` };
     }
-    return { ok: true, content: skill.replace(patch.anchor, patch.payload) };
+    return { ok: true, content: skill.replace(patch.anchor, () => patch.payload) };
   }
 
   return { ok: false, reason: `unknown op: ${(patch as Patch).op}` };

--- a/src/optimizer/clip.ts
+++ b/src/optimizer/clip.ts
@@ -1,0 +1,25 @@
+import type { Patch, LRBudget } from './types';
+
+export interface ClipResult {
+  selected: Patch[];
+  clipped: Patch[];
+}
+
+export function clipByLR(patches: Patch[], budget: LRBudget): ClipResult {
+  const buckets: Record<Patch['op'], Patch[]> = { add: [], delete: [], replace: [] };
+  for (const p of patches) buckets[p.op].push(p);
+
+  const selected: Patch[] = [];
+  const clipped: Patch[] = [];
+
+  function take(op: Patch['op'], limit: number) {
+    selected.push(...buckets[op].slice(0, limit));
+    clipped.push(...buckets[op].slice(limit));
+  }
+
+  take('delete', budget.maxDeletes);
+  take('replace', budget.maxReplaces);
+  take('add', budget.maxAdds);
+
+  return { selected, clipped };
+}

--- a/src/optimizer/hash.ts
+++ b/src/optimizer/hash.ts
@@ -1,0 +1,5 @@
+import { createHash } from 'node:crypto';
+
+export function skillHash(content: string): string {
+  return createHash('sha256').update(content, 'utf8').digest('hex').slice(0, 16);
+}

--- a/src/optimizer/llm.ts
+++ b/src/optimizer/llm.ts
@@ -1,0 +1,119 @@
+import * as https from 'node:https';
+
+export type Provider = 'anthropic' | 'openai' | 'openrouter' | 'fireworks';
+
+export interface LLMRequest {
+  provider: Provider;
+  model: string;
+  system: string;
+  user: string;
+  maxTokens?: number;
+  temperature?: number;
+}
+
+export interface LLMResponse {
+  text: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+}
+
+const PROVIDER_CFG: Record<Provider, { host: string; path: string; envKey: string }> = {
+  anthropic: { host: 'api.anthropic.com', path: '/v1/messages', envKey: 'ANTHROPIC_API_KEY' },
+  openai: { host: 'api.openai.com', path: '/v1/chat/completions', envKey: 'OPENAI_API_KEY' },
+  openrouter: { host: 'openrouter.ai', path: '/api/v1/chat/completions', envKey: 'OPENROUTER_API_KEY' },
+  fireworks: { host: 'api.fireworks.ai', path: '/inference/v1/chat/completions', envKey: 'FIREWORKS_API_KEY' },
+};
+
+const PRICE_PER_M_TOKENS: Record<string, { input: number; output: number }> = {
+  'claude-opus-4-7': { input: 15, output: 75 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5-20251001': { input: 1, output: 5 },
+  'gpt-4o': { input: 2.5, output: 10 },
+  'gpt-4o-mini': { input: 0.15, output: 0.6 },
+};
+
+export async function callLLM(req: LLMRequest): Promise<LLMResponse> {
+  const cfg = PROVIDER_CFG[req.provider];
+  const apiKey = process.env[cfg.envKey];
+  if (!apiKey) throw new Error(`${cfg.envKey} not set in environment`);
+
+  const body = req.provider === 'anthropic'
+    ? buildAnthropicBody(req)
+    : buildOpenAIBody(req);
+
+  const headers: Record<string, string> = req.provider === 'anthropic'
+    ? { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' }
+    : { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' };
+
+  const raw = await postJson(cfg.host, cfg.path, headers, body);
+  const parsed = JSON.parse(raw);
+  const text = extractText(req.provider, parsed);
+  const usage = extractUsage(req.provider, parsed);
+  const price = PRICE_PER_M_TOKENS[req.model] ?? { input: 0, output: 0 };
+  const costUsd = (usage.input / 1_000_000) * price.input + (usage.output / 1_000_000) * price.output;
+
+  return { text, inputTokens: usage.input, outputTokens: usage.output, costUsd };
+}
+
+function buildAnthropicBody(req: LLMRequest): string {
+  return JSON.stringify({
+    model: req.model,
+    max_tokens: req.maxTokens ?? 4096,
+    temperature: req.temperature ?? 0.2,
+    system: req.system,
+    messages: [{ role: 'user', content: req.user }],
+  });
+}
+
+function buildOpenAIBody(req: LLMRequest): string {
+  return JSON.stringify({
+    model: req.model,
+    max_tokens: req.maxTokens ?? 4096,
+    temperature: req.temperature ?? 0.2,
+    messages: [
+      { role: 'system', content: req.system },
+      { role: 'user', content: req.user },
+    ],
+  });
+}
+
+function extractText(provider: Provider, body: unknown): string {
+  const obj = body as Record<string, unknown>;
+  if (provider === 'anthropic') {
+    const content = obj.content as Array<{ type: string; text?: string }> | undefined;
+    return content?.find((c) => c.type === 'text')?.text ?? '';
+  }
+  const choices = obj.choices as Array<{ message?: { content?: string } }> | undefined;
+  return choices?.[0]?.message?.content ?? '';
+}
+
+function extractUsage(provider: Provider, body: unknown): { input: number; output: number } {
+  const obj = body as Record<string, unknown>;
+  if (provider === 'anthropic') {
+    const u = obj.usage as { input_tokens?: number; output_tokens?: number } | undefined;
+    return { input: u?.input_tokens ?? 0, output: u?.output_tokens ?? 0 };
+  }
+  const u = obj.usage as { prompt_tokens?: number; completion_tokens?: number } | undefined;
+  return { input: u?.prompt_tokens ?? 0, output: u?.completion_tokens ?? 0 };
+}
+
+function postJson(host: string, path: string, headers: Record<string, string>, body: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const req = https.request(
+      { host, path, method: 'POST', headers: { ...headers, 'content-length': Buffer.byteLength(body).toString() } },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const text = Buffer.concat(chunks).toString('utf8');
+          if ((res.statusCode ?? 500) >= 400) reject(new Error(`HTTP ${res.statusCode}: ${text.slice(0, 500)}`));
+          else resolve(text);
+        });
+      },
+    );
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}

--- a/src/optimizer/llm.ts
+++ b/src/optimizer/llm.ts
@@ -1,5 +1,7 @@
 import * as https from 'node:https';
 
+const DEFAULT_TIMEOUT_MS = 120_000;
+
 export type Provider = 'anthropic' | 'openai' | 'openrouter' | 'fireworks';
 
 export interface LLMRequest {
@@ -46,11 +48,19 @@ export async function callLLM(req: LLMRequest): Promise<LLMResponse> {
     ? { 'x-api-key': apiKey, 'anthropic-version': '2023-06-01', 'content-type': 'application/json' }
     : { authorization: `Bearer ${apiKey}`, 'content-type': 'application/json' };
 
+  const price = PRICE_PER_M_TOKENS[req.model];
+  if (!price) {
+    const known = Object.keys(PRICE_PER_M_TOKENS).join(', ');
+    throw new Error(
+      `Unknown model "${req.model}". Budget cap cannot be enforced. ` +
+      `Add a price entry to PRICE_PER_M_TOKENS in src/optimizer/llm.ts or pick one of: ${known}.`,
+    );
+  }
+
   const raw = await postJson(cfg.host, cfg.path, headers, body);
   const parsed = JSON.parse(raw);
   const text = extractText(req.provider, parsed);
   const usage = extractUsage(req.provider, parsed);
-  const price = PRICE_PER_M_TOKENS[req.model] ?? { input: 0, output: 0 };
   const costUsd = (usage.input / 1_000_000) * price.input + (usage.output / 1_000_000) * price.output;
 
   return { text, inputTokens: usage.input, outputTokens: usage.output, costUsd };
@@ -99,7 +109,19 @@ function extractUsage(provider: Provider, body: unknown): { input: number; outpu
 }
 
 function postJson(host: string, path: string, headers: Record<string, string>, body: string): Promise<string> {
+  const timeoutMs = parseInt(process.env.SKILL_OPTIMIZER_TIMEOUT_MS ?? '', 10) || DEFAULT_TIMEOUT_MS;
   return new Promise((resolve, reject) => {
+    let timer: NodeJS.Timeout | null = null;
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      fn();
+    };
     const req = https.request(
       { host, path, method: 'POST', headers: { ...headers, 'content-length': Buffer.byteLength(body).toString() } },
       (res) => {
@@ -107,12 +129,19 @@ function postJson(host: string, path: string, headers: Record<string, string>, b
         res.on('data', (c) => chunks.push(c));
         res.on('end', () => {
           const text = Buffer.concat(chunks).toString('utf8');
-          if ((res.statusCode ?? 500) >= 400) reject(new Error(`HTTP ${res.statusCode}: ${text.slice(0, 500)}`));
-          else resolve(text);
+          if ((res.statusCode ?? 500) >= 400) {
+            settle(() => reject(new Error(`HTTP ${res.statusCode}: ${text.slice(0, 500)}`)));
+          } else {
+            settle(() => resolve(text));
+          }
         });
+        res.on('error', (err) => settle(() => reject(err)));
       },
     );
-    req.on('error', reject);
+    req.on('error', (err) => settle(() => reject(err)));
+    timer = setTimeout(() => {
+      req.destroy(new Error(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
     req.write(body);
     req.end();
   });

--- a/src/optimizer/parse.ts
+++ b/src/optimizer/parse.ts
@@ -1,0 +1,8 @@
+export function stripFencesAndParse<T = unknown>(text: string): T | null {
+  const stripped = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
+  try {
+    return JSON.parse(stripped) as T;
+  } catch {
+    return null;
+  }
+}

--- a/src/optimizer/reflect.ts
+++ b/src/optimizer/reflect.ts
@@ -1,5 +1,6 @@
 import type { LRBudget, Patch, ReflectInput, ReflectOutput, Rejection, Trajectory } from './types';
 import { callLLM, type Provider } from './llm';
+import { stripFencesAndParse } from './parse';
 
 export interface ReflectArgs {
   input: ReflectInput;
@@ -67,15 +68,8 @@ function formatRejection(r: Rejection): Record<string, unknown> {
 }
 
 function parsePatches(text: string): Patch[] {
-  const stripped = stripFences(text).trim();
-  let obj: unknown;
-  try {
-    obj = JSON.parse(stripped);
-  } catch {
-    return [];
-  }
-  const root = obj as { patches?: unknown };
-  if (!Array.isArray(root.patches)) return [];
+  const root = stripFencesAndParse<{ patches?: unknown }>(text);
+  if (!root || !Array.isArray(root.patches)) return [];
   const out: Patch[] = [];
   for (const raw of root.patches) {
     const p = raw as Record<string, unknown>;
@@ -87,17 +81,8 @@ function parsePatches(text: string): Patch[] {
 }
 
 function extractReasoning(text: string): string {
-  const stripped = stripFences(text).trim();
-  try {
-    const obj = JSON.parse(stripped) as { reasoning?: string };
-    return obj.reasoning ?? '';
-  } catch {
-    return '';
-  }
-}
-
-function stripFences(s: string): string {
-  return s.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+  const root = stripFencesAndParse<{ reasoning?: string }>(text);
+  return root?.reasoning ?? '';
 }
 
 export const __test = { parsePatches, extractReasoning };

--- a/src/optimizer/reflect.ts
+++ b/src/optimizer/reflect.ts
@@ -1,0 +1,103 @@
+import type { LRBudget, Patch, ReflectInput, ReflectOutput, Rejection, Trajectory } from './types';
+import { callLLM, type Provider } from './llm';
+
+export interface ReflectArgs {
+  input: ReflectInput;
+  provider: Provider;
+  model: string;
+}
+
+export async function reflect({ input, provider, model }: ReflectArgs): Promise<ReflectOutput> {
+  const system = SYSTEM_PROMPT;
+  const user = buildUserPrompt(input);
+  const res = await callLLM({
+    provider,
+    model,
+    system,
+    user,
+    maxTokens: 4096,
+    temperature: 0.2,
+  });
+  const patches = parsePatches(res.text);
+  return { patches, reasoning: extractReasoning(res.text), costUsd: res.costUsd };
+}
+
+const SYSTEM_PROMPT = `You are a SkillOpt optimizer. Given the current skill markdown, recent correction trajectories, and a list of previously rejected patches, propose bounded edits to the skill document.
+
+Output STRICT JSON only, no prose, no markdown fences. Schema:
+{
+  "reasoning": "<one short paragraph explaining the edit theme>",
+  "patches": [
+    { "op": "add" | "delete" | "replace", "anchor": "<exact substring from current skill, or empty string for append-at-end add>", "payload": "<new text for add/replace; empty for delete>" }
+  ]
+}
+
+Constraints:
+- Each patch operates on a unique anchor string.
+- "anchor" MUST be a verbatim substring of the current skill (or empty for append).
+- Do not propose patches that match any entry in the rejected_history.
+- Respect the LR budget: at most N adds, N deletes, N replaces.
+- Patches must address concrete correction patterns from the trajectories, not vague style.`;
+
+function buildUserPrompt(input: ReflectInput): string {
+  return JSON.stringify({
+    current_skill: input.currentSkill,
+    trajectories: input.trajectories.map(formatTrajectory),
+    rejected_history: input.rejectedHistory.map(formatRejection),
+    lr_budget: input.lrBudget,
+  });
+}
+
+function formatTrajectory(t: Trajectory): Record<string, unknown> {
+  return {
+    category: t.category,
+    rule: t.rule,
+    mistake: t.mistake,
+    correction: t.correction,
+    times_applied: t.timesApplied,
+  };
+}
+
+function formatRejection(r: Rejection): Record<string, unknown> {
+  return {
+    patches: r.patches,
+    reason: r.reason,
+    delta_score: r.deltaScore,
+  };
+}
+
+function parsePatches(text: string): Patch[] {
+  const stripped = stripFences(text).trim();
+  let obj: unknown;
+  try {
+    obj = JSON.parse(stripped);
+  } catch {
+    return [];
+  }
+  const root = obj as { patches?: unknown };
+  if (!Array.isArray(root.patches)) return [];
+  const out: Patch[] = [];
+  for (const raw of root.patches) {
+    const p = raw as Record<string, unknown>;
+    if (typeof p.op !== 'string' || typeof p.anchor !== 'string' || typeof p.payload !== 'string') continue;
+    if (p.op !== 'add' && p.op !== 'delete' && p.op !== 'replace') continue;
+    out.push({ op: p.op, anchor: p.anchor, payload: p.payload });
+  }
+  return out;
+}
+
+function extractReasoning(text: string): string {
+  const stripped = stripFences(text).trim();
+  try {
+    const obj = JSON.parse(stripped) as { reasoning?: string };
+    return obj.reasoning ?? '';
+  } catch {
+    return '';
+  }
+}
+
+function stripFences(s: string): string {
+  return s.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '');
+}
+
+export const __test = { parsePatches, extractReasoning };

--- a/src/optimizer/slow.ts
+++ b/src/optimizer/slow.ts
@@ -1,5 +1,6 @@
 import type { Trajectory } from './types';
 import { callLLM, type Provider } from './llm';
+import { stripFencesAndParse } from './parse';
 
 export interface SlowUpdateArgs {
   bestSkill: string;
@@ -57,10 +58,5 @@ Rules:
 }
 
 function parse(text: string): { skill?: string; reasoning?: string } {
-  const stripped = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
-  try {
-    return JSON.parse(stripped);
-  } catch {
-    return {};
-  }
+  return stripFencesAndParse<{ skill?: string; reasoning?: string }>(text) ?? {};
 }

--- a/src/optimizer/slow.ts
+++ b/src/optimizer/slow.ts
@@ -1,0 +1,66 @@
+import type { Trajectory } from './types';
+import { callLLM, type Provider } from './llm';
+
+export interface SlowUpdateArgs {
+  bestSkill: string;
+  recentlyAcceptedDiffs: string[];
+  acceptedTrajectories: Trajectory[];
+  provider: Provider;
+  model: string;
+}
+
+export interface SlowUpdateResult {
+  skill: string;
+  costUsd: number;
+  reasoning: string;
+  changed: boolean;
+}
+
+export async function runSlowUpdate({
+  bestSkill,
+  recentlyAcceptedDiffs,
+  acceptedTrajectories,
+  provider,
+  model,
+}: SlowUpdateArgs): Promise<SlowUpdateResult> {
+  const system = `You are a SkillOpt slow-update consolidator. Given the current best skill, a list of recently accepted edits, and the trajectories that justified them, produce a single coherent rewrite of the skill that preserves all accepted intent but removes redundancy, normalizes structure, and tightens phrasing.
+
+Output STRICT JSON only:
+{
+  "reasoning": "<one paragraph explaining the consolidation>",
+  "skill": "<full rewritten markdown>"
+}
+
+Rules:
+- No new behavior that isn't implied by accepted edits.
+- Preserve all section headings that existed in the best skill.
+- Total length <= 2,000 tokens.`;
+
+  const user = JSON.stringify({
+    best_skill: bestSkill,
+    accepted_diffs: recentlyAcceptedDiffs,
+    accepted_trajectories: acceptedTrajectories.map((t) => ({
+      category: t.category,
+      rule: t.rule,
+      correction: t.correction,
+    })),
+  });
+
+  const res = await callLLM({ provider, model, system, user, maxTokens: 8192, temperature: 0.2 });
+  const parsed = parse(res.text);
+  return {
+    skill: parsed.skill ?? bestSkill,
+    reasoning: parsed.reasoning ?? '',
+    changed: (parsed.skill ?? bestSkill) !== bestSkill,
+    costUsd: res.costUsd,
+  };
+}
+
+function parse(text: string): { skill?: string; reasoning?: string } {
+  const stripped = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    return {};
+  }
+}

--- a/src/optimizer/store.ts
+++ b/src/optimizer/store.ts
@@ -1,0 +1,309 @@
+import Database from 'better-sqlite3';
+import { initializeDatabase, getDefaultDbPath } from '../db/index';
+import type {
+  Candidate,
+  OptimizationRun,
+  Patch,
+  Rejection,
+  TrainerConfig,
+  Trajectory,
+  ValidationItem,
+} from './types';
+
+export interface OptimizerStore {
+  db: Database.Database;
+  createRun: (run: Omit<OptimizationRun, 'id'>) => number;
+  updateRun: (id: number, fields: Partial<OptimizationRun>) => void;
+  endRun: (id: number, status: OptimizationRun['status'], reason?: string) => void;
+  saveCandidate: (c: Omit<Candidate, 'id'>) => number;
+  markCandidate: (id: number, status: Candidate['status'], score: number) => void;
+  recordPatches: (runId: number, candidateId: number, step: number, epoch: number, patches: Patch[], status?: string) => void;
+  rejectPatches: (runId: number, candidateId: number, step: number, epoch: number, patches: Patch[], reason: string) => void;
+  saveRejection: (r: Rejection) => void;
+  getRejections: (runId: number, limit: number) => Rejection[];
+  collectTrajectories: (skillSlug: string, limit: number) => Trajectory[];
+  listValidation: (skillSlug: string) => ValidationItem[];
+  upsertValidation: (skillSlug: string, items: Array<Omit<ValidationItem, 'id' | 'frozenAt'>>) => number;
+  close: () => void;
+}
+
+export function createOptimizerStore(dbPath: string = getDefaultDbPath()): OptimizerStore {
+  const db = initializeDatabase(dbPath);
+
+  const createRunStmt = db.prepare(`
+    INSERT INTO optimization_runs (
+      skill_slug, status, initial_skill_hash, best_skill_hash,
+      initial_score, best_score, epochs_completed, accepted_steps, rejected_steps,
+      budget_usd, spent_usd, config_json, reason
+    ) VALUES (
+      @skill_slug, @status, @initial_skill_hash, @best_skill_hash,
+      @initial_score, @best_score, @epochs_completed, @accepted_steps, @rejected_steps,
+      @budget_usd, @spent_usd, @config_json, @reason
+    )
+  `);
+
+  const endRunStmt = db.prepare(`
+    UPDATE optimization_runs
+    SET status = @status, reason = COALESCE(@reason, reason), ended_at = datetime('now')
+    WHERE id = @id
+  `);
+
+  const insertCandStmt = db.prepare(`
+    INSERT INTO optimization_candidates (
+      run_id, parent_hash, content_hash, content, source_patches_json,
+      step, epoch, score, status
+    ) VALUES (
+      @run_id, @parent_hash, @content_hash, @content, @source_patches_json,
+      @step, @epoch, @score, @status
+    )
+    ON CONFLICT(run_id, content_hash) DO UPDATE SET
+      score = excluded.score,
+      status = excluded.status
+    RETURNING id
+  `);
+
+  const markCandStmt = db.prepare(`
+    UPDATE optimization_candidates
+    SET status = @status, score = @score, evaluated_at = datetime('now')
+    WHERE id = @id
+  `);
+
+  const insertPatchStmt = db.prepare(`
+    INSERT INTO optimization_patches (
+      run_id, candidate_id, step, epoch, op, anchor, payload, status, rejected_reason
+    ) VALUES (
+      @run_id, @candidate_id, @step, @epoch, @op, @anchor, @payload, @status, @rejected_reason
+    )
+  `);
+
+  const insertRejectionStmt = db.prepare(`
+    INSERT INTO optimization_rejections (run_id, candidate_hash, patches_json, reason, delta_score)
+    VALUES (@run_id, @candidate_hash, @patches_json, @reason, @delta_score)
+  `);
+
+  const listRejectionsStmt = db.prepare(`
+    SELECT run_id, candidate_hash, patches_json, reason, delta_score
+    FROM optimization_rejections
+    WHERE run_id = ?
+    ORDER BY id DESC
+    LIMIT ?
+  `);
+
+  const collectTrajStmt = db.prepare(`
+    SELECT id, category, rule, mistake, correction, times_applied, created_at
+    FROM learnings
+    WHERE project IS NULL OR project = @slug
+    ORDER BY times_applied DESC, created_at DESC
+    LIMIT @limit
+  `);
+
+  const listValidationStmt = db.prepare(`
+    SELECT id, skill_slug, prompt, expected, weight, frozen_at
+    FROM optimization_validation
+    WHERE skill_slug = ?
+  `);
+
+  const insertValidationStmt = db.prepare(`
+    INSERT INTO optimization_validation (skill_slug, learning_id, prompt, expected, weight)
+    VALUES (@skill_slug, @learning_id, @prompt, @expected, @weight)
+  `);
+
+  return {
+    db,
+    createRun(run) {
+      const info = createRunStmt.run({
+        skill_slug: run.skillSlug,
+        status: run.status,
+        initial_skill_hash: run.initialSkillHash,
+        best_skill_hash: run.bestSkillHash,
+        initial_score: run.initialScore,
+        best_score: run.bestScore,
+        epochs_completed: run.epochsCompleted,
+        accepted_steps: run.acceptedSteps,
+        rejected_steps: run.rejectedSteps,
+        budget_usd: run.budgetUsd,
+        spent_usd: run.spentUsd,
+        config_json: JSON.stringify(run.config),
+        reason: run.reason,
+      });
+      return Number(info.lastInsertRowid);
+    },
+
+    updateRun(id, fields) {
+      const sets: string[] = [];
+      const params: Record<string, unknown> = { id };
+      if (fields.bestSkillHash !== undefined) { sets.push('best_skill_hash = @bestSkillHash'); params.bestSkillHash = fields.bestSkillHash; }
+      if (fields.bestScore !== undefined) { sets.push('best_score = @bestScore'); params.bestScore = fields.bestScore; }
+      if (fields.initialScore !== undefined) { sets.push('initial_score = @initialScore'); params.initialScore = fields.initialScore; }
+      if (fields.epochsCompleted !== undefined) { sets.push('epochs_completed = @epochsCompleted'); params.epochsCompleted = fields.epochsCompleted; }
+      if (fields.acceptedSteps !== undefined) { sets.push('accepted_steps = @acceptedSteps'); params.acceptedSteps = fields.acceptedSteps; }
+      if (fields.rejectedSteps !== undefined) { sets.push('rejected_steps = @rejectedSteps'); params.rejectedSteps = fields.rejectedSteps; }
+      if (fields.spentUsd !== undefined) { sets.push('spent_usd = @spentUsd'); params.spentUsd = fields.spentUsd; }
+      if (sets.length === 0) return;
+      db.prepare(`UPDATE optimization_runs SET ${sets.join(', ')} WHERE id = @id`).run(params);
+    },
+
+    endRun(id, status, reason) {
+      endRunStmt.run({ id, status, reason: reason ?? null });
+    },
+
+    saveCandidate(c) {
+      const row = insertCandStmt.get({
+        run_id: c.runId,
+        parent_hash: c.parentHash,
+        content_hash: c.contentHash,
+        content: c.content,
+        source_patches_json: JSON.stringify(c.sourcePatches),
+        step: c.step,
+        epoch: c.epoch,
+        score: c.score ?? null,
+        status: c.status,
+      }) as { id: number };
+      return row.id;
+    },
+
+    markCandidate(id, status, score) {
+      markCandStmt.run({ id, status, score });
+    },
+
+    recordPatches(runId, candidateId, step, epoch, patches, status = 'applied') {
+      const insert = db.transaction(() => {
+        for (const p of patches) {
+          insertPatchStmt.run({
+            run_id: runId,
+            candidate_id: candidateId,
+            step,
+            epoch,
+            op: p.op,
+            anchor: p.anchor,
+            payload: p.payload,
+            status,
+            rejected_reason: null,
+          });
+        }
+      });
+      insert();
+    },
+
+    rejectPatches(runId, candidateId, step, epoch, patches, reason) {
+      const insert = db.transaction(() => {
+        for (const p of patches) {
+          insertPatchStmt.run({
+            run_id: runId,
+            candidate_id: candidateId,
+            step,
+            epoch,
+            op: p.op,
+            anchor: p.anchor,
+            payload: p.payload,
+            status: 'rejected',
+            rejected_reason: reason,
+          });
+        }
+      });
+      insert();
+    },
+
+    saveRejection(r) {
+      insertRejectionStmt.run({
+        run_id: r.runId,
+        candidate_hash: r.candidateHash,
+        patches_json: JSON.stringify(r.patches),
+        reason: r.reason,
+        delta_score: r.deltaScore,
+      });
+    },
+
+    getRejections(runId, limit) {
+      const rows = listRejectionsStmt.all(runId, limit) as Array<{
+        run_id: number;
+        candidate_hash: string;
+        patches_json: string;
+        reason: string;
+        delta_score: number | null;
+      }>;
+      return rows.map((row) => ({
+        runId: row.run_id,
+        candidateHash: row.candidate_hash,
+        patches: JSON.parse(row.patches_json) as Patch[],
+        reason: row.reason,
+        deltaScore: row.delta_score,
+      }));
+    },
+
+    collectTrajectories(slug, limit) {
+      const rows = collectTrajStmt.all({ slug, limit }) as Array<{
+        id: number;
+        category: string;
+        rule: string;
+        mistake: string | null;
+        correction: string | null;
+        times_applied: number;
+        created_at: string;
+      }>;
+      return rows.map((r) => ({
+        learningId: r.id,
+        category: r.category,
+        rule: r.rule,
+        mistake: r.mistake,
+        correction: r.correction,
+        timesApplied: r.times_applied,
+        createdAt: r.created_at,
+      }));
+    },
+
+    listValidation(slug) {
+      const rows = listValidationStmt.all(slug) as Array<{
+        id: number; skill_slug: string; prompt: string; expected: string; weight: number; frozen_at: string;
+      }>;
+      return rows.map((r) => ({
+        id: r.id,
+        skillSlug: r.skill_slug,
+        prompt: r.prompt,
+        expected: r.expected,
+        weight: r.weight,
+        frozenAt: r.frozen_at,
+      }));
+    },
+
+    upsertValidation(slug, items) {
+      const insert = db.transaction(() => {
+        for (const it of items) {
+          insertValidationStmt.run({
+            skill_slug: slug,
+            learning_id: null,
+            prompt: it.prompt,
+            expected: it.expected,
+            weight: it.weight,
+          });
+        }
+      });
+      insert();
+      return items.length;
+    },
+
+    close() {
+      db.close();
+    },
+  };
+}
+
+export function trajectoriesToValidation(
+  slug: string,
+  trajectories: Trajectory[],
+  holdout: number,
+): { train: Trajectory[]; validation: Array<Omit<ValidationItem, 'id' | 'frozenAt'>> } {
+  const sorted = [...trajectories].sort((a, b) => (a.timesApplied - b.timesApplied) || (a.learningId - b.learningId));
+  const valCount = Math.min(holdout, Math.floor(sorted.length / 4));
+  const validationRows = sorted.slice(-valCount);
+  const trainRows = sorted.slice(0, sorted.length - valCount);
+  const validation = validationRows.map((t) => ({
+    skillSlug: slug,
+    prompt: t.mistake ?? `Scenario from category "${t.category}"`,
+    expected: t.correction ?? t.rule,
+    weight: 1 + Math.min(2, Math.log2(1 + t.timesApplied)),
+  }));
+  return { train: trainRows, validation };
+}
+
+export const __test = { trajectoriesToValidation };

--- a/src/optimizer/store.ts
+++ b/src/optimizer/store.ts
@@ -1,4 +1,5 @@
 import Database from 'better-sqlite3';
+import { createHash } from 'node:crypto';
 import { initializeDatabase, getDefaultDbPath } from '../db/index';
 import type {
   Candidate,
@@ -23,7 +24,10 @@ export interface OptimizerStore {
   getRejections: (runId: number, limit: number) => Rejection[];
   collectTrajectories: (skillSlug: string, limit: number) => Trajectory[];
   listValidation: (skillSlug: string) => ValidationItem[];
-  upsertValidation: (skillSlug: string, items: Array<Omit<ValidationItem, 'id' | 'frozenAt'>>) => number;
+  upsertValidation: (
+    skillSlug: string,
+    items: Array<Omit<ValidationItem, 'id' | 'frozenAt'> & { learningId?: number | null }>,
+  ) => number;
   close: () => void;
 }
 
@@ -104,8 +108,11 @@ export function createOptimizerStore(dbPath: string = getDefaultDbPath()): Optim
   `);
 
   const insertValidationStmt = db.prepare(`
-    INSERT INTO optimization_validation (skill_slug, learning_id, prompt, expected, weight)
-    VALUES (@skill_slug, @learning_id, @prompt, @expected, @weight)
+    INSERT INTO optimization_validation (skill_slug, learning_id, prompt_hash, prompt, expected, weight)
+    VALUES (@skill_slug, @learning_id, @prompt_hash, @prompt, @expected, @weight)
+    ON CONFLICT(skill_slug, prompt_hash) DO UPDATE SET
+      expected = excluded.expected,
+      weight = excluded.weight
   `);
 
   return {
@@ -269,9 +276,11 @@ export function createOptimizerStore(dbPath: string = getDefaultDbPath()): Optim
     upsertValidation(slug, items) {
       const insert = db.transaction(() => {
         for (const it of items) {
+          const promptHash = createHash('sha256').update(it.prompt, 'utf8').digest('hex').slice(0, 16);
           insertValidationStmt.run({
             skill_slug: slug,
-            learning_id: null,
+            learning_id: it.learningId ?? null,
+            prompt_hash: promptHash,
             prompt: it.prompt,
             expected: it.expected,
             weight: it.weight,
@@ -292,13 +301,17 @@ export function trajectoriesToValidation(
   slug: string,
   trajectories: Trajectory[],
   holdout: number,
-): { train: Trajectory[]; validation: Array<Omit<ValidationItem, 'id' | 'frozenAt'>> } {
+): {
+  train: Trajectory[];
+  validation: Array<Omit<ValidationItem, 'id' | 'frozenAt'> & { learningId: number }>;
+} {
   const sorted = [...trajectories].sort((a, b) => (a.timesApplied - b.timesApplied) || (a.learningId - b.learningId));
   const valCount = Math.min(holdout, Math.floor(sorted.length / 4));
   const validationRows = sorted.slice(-valCount);
   const trainRows = sorted.slice(0, sorted.length - valCount);
   const validation = validationRows.map((t) => ({
     skillSlug: slug,
+    learningId: t.learningId,
     prompt: t.mistake ?? `Scenario from category "${t.category}"`,
     expected: t.correction ?? t.rule,
     weight: 1 + Math.min(2, Math.log2(1 + t.timesApplied)),

--- a/src/optimizer/trainer.ts
+++ b/src/optimizer/trainer.ts
@@ -6,15 +6,10 @@ import { reflect } from './reflect';
 import { runSlowUpdate } from './slow';
 import { validateSkill } from './validate';
 import { createOptimizerStore, trajectoriesToValidation, type OptimizerStore } from './store';
-import type {
-  Candidate,
-  OptimizationRun,
-  Patch,
-  TrainerConfig,
-  Trajectory,
-  ValidationItem,
-} from './types';
+import type { Candidate, Patch, TrainerConfig, Trajectory } from './types';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+const STAMP_RE = /\n?<!-- skill-optimizer: [^>]*-->\s*$/g;
 
 export interface TrainerArgs {
   skillSlug: string;
@@ -41,7 +36,7 @@ export interface TrainerOutcome {
 export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
   const log = args.logger ?? ((line: string) => process.stderr.write(`[skill-optimizer] ${line}\n`));
   const store = args.store ?? createOptimizerStore();
-  let ownStore = !args.store;
+  const ownStore = !args.store;
 
   try {
     const initialSkill = readFileSync(args.skillPath, 'utf8');
@@ -77,192 +72,244 @@ export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
       reason: null,
     });
 
-    const initialEval = await validateSkill({
-      skill: initialSkill,
-      items: validationItems,
-      provider: args.config.evaluatorProvider,
-      model: args.config.evaluatorModel,
-    });
-    let spent = initialEval.costUsd;
+    let spent = 0;
     let bestSkill = initialSkill;
-    let bestScore = initialEval.result.weightedScore;
     let bestHash = initialHash;
-    store.updateRun(runId, { initialScore: bestScore, bestScore });
-    log(`baseline: score=${bestScore.toFixed(3)} (${initialEval.result.passed}/${initialEval.result.total})`);
-
     let accepted = 0;
     let rejected = 0;
     let epoch = 0;
     let stoppedReason = 'completed';
+    const recentlyAcceptedDiffs: string[] = [];
+    let initialScoreValue = 0;
+    let bestScore = 0;
 
-    for (epoch = 1; epoch <= args.config.epochs; epoch++) {
-      if (existsSync(args.config.killSwitchPath)) {
-        stoppedReason = `kill-switch ${args.config.killSwitchPath}`;
-        break;
-      }
-      if (spent >= args.config.budgetUsd) {
-        stoppedReason = `budget exhausted at $${spent.toFixed(2)}`;
-        break;
-      }
+    const flushAndEnd = (status: 'completed' | 'failed' | 'stopped', reason: string) => {
+      store.updateRun(runId, {
+        spentUsd: spent,
+        acceptedSteps: accepted,
+        rejectedSteps: rejected,
+        epochsCompleted: epoch,
+        bestSkillHash: bestHash,
+        bestScore,
+      });
+      store.endRun(runId, status, reason);
+    };
 
-      const batches = makeMinibatches(trainTraj, args.config.batchSize, args.config.minibatches);
-      log(`epoch ${epoch}: ${batches.length} minibatch(es) of ~${args.config.batchSize}`);
-
-      const epochPatchBatches: Patch[][] = [];
-      for (let b = 0; b < batches.length; b++) {
-        const batchPatches = await reflect({
-          input: {
-            currentSkill: bestSkill,
-            trajectories: batches[b],
-            rejectedHistory: store.getRejections(runId, 10),
-            lrBudget: args.config.lrBudget,
-          },
-          provider: args.config.optimizerProvider,
-          model: args.config.optimizerModel,
-        });
-        spent += batchPatches.costUsd;
-        store.updateRun(runId, { spentUsd: spent });
-        epochPatchBatches.push(batchPatches.patches);
-        log(`  minibatch ${b + 1}/${batches.length}: ${batchPatches.patches.length} raw patches (spent $${spent.toFixed(3)})`);
-        if (spent >= args.config.budgetUsd) break;
+    const guardBudget = (estimateUsd: number, label: string): boolean => {
+      const remaining = args.config.budgetUsd - spent;
+      if (remaining <= 0 || remaining < estimateUsd) {
+        log(`  budget guard: $${remaining.toFixed(3)} left, skipping ${label}`);
+        stoppedReason = `budget exhausted before ${label} (spent $${spent.toFixed(3)})`;
+        return false;
       }
+      return true;
+    };
 
-      const aggregated = aggregatePatches(epochPatchBatches);
-      const clipped = clipByLR(aggregated.merged, args.config.lrBudget);
-      if (clipped.selected.length === 0) {
-        log(`  no patches selected; continuing`);
-        continue;
+    try {
+      if (!guardBudget(0.005, 'baseline eval')) {
+        flushAndEnd('stopped', stoppedReason);
+        return outcome(runId, bestSkill, bestHash, 0, 0, epoch, accepted, rejected, spent, stoppedReason);
       }
-
-      const { content: candContent, applied, skipped } = applyPatches(bestSkill, clipped.selected);
-      const candidateHash = skillHash(candContent);
-      if (candidateHash === bestHash) {
-        log(`  candidate identical to best after apply; skipping`);
-        continue;
-      }
-      if (candidateTokens(candContent) > args.config.maxSkillTokens) {
-        log(`  candidate exceeds maxSkillTokens (${args.config.maxSkillTokens}); rejecting`);
-        rejected++;
-        store.saveRejection({
-          runId,
-          candidateHash,
-          patches: applied,
-          reason: 'exceeds_max_tokens',
-          deltaScore: null,
-        });
-        continue;
-      }
-
-      const cand: Omit<Candidate, 'id'> = {
-        runId,
-        parentHash: bestHash,
-        contentHash: candidateHash,
-        content: candContent,
-        sourcePatches: applied,
-        step: accepted + rejected + 1,
-        epoch,
-        status: 'pending',
-      };
-      const candidateId = store.saveCandidate(cand);
-      store.recordPatches(runId, candidateId, cand.step, epoch, applied, 'applied');
-      if (skipped.length > 0) {
-        store.rejectPatches(runId, candidateId, cand.step, epoch, skipped.map((s) => s.patch), 'anchor_missing');
-      }
-
-      const evalRes = await validateSkill({
-        skill: candContent,
+      const initialEval = await validateSkill({
+        skill: initialSkill,
         items: validationItems,
         provider: args.config.evaluatorProvider,
         model: args.config.evaluatorModel,
       });
-      spent += evalRes.costUsd;
-      store.updateRun(runId, { spentUsd: spent });
+      spent += initialEval.costUsd;
+      initialScoreValue = initialEval.result.weightedScore;
+      bestScore = initialScoreValue;
+      store.updateRun(runId, { spentUsd: spent, initialScore: initialScoreValue, bestScore });
+      log(`baseline: score=${bestScore.toFixed(3)} (${initialEval.result.passed}/${initialEval.result.total})`);
 
-      const delta = evalRes.result.weightedScore - bestScore;
-      log(`  candidate score=${evalRes.result.weightedScore.toFixed(3)} (delta=${delta >= 0 ? '+' : ''}${delta.toFixed(3)})`);
+      for (epoch = 1; epoch <= args.config.epochs; epoch++) {
+        if (existsSync(args.config.killSwitchPath)) {
+          stoppedReason = `kill-switch ${args.config.killSwitchPath}`;
+          break;
+        }
+        if (spent >= args.config.budgetUsd) {
+          stoppedReason = `budget exhausted at $${spent.toFixed(2)}`;
+          break;
+        }
 
-      if (delta >= args.config.acceptThreshold) {
-        accepted++;
-        bestSkill = candContent;
-        bestScore = evalRes.result.weightedScore;
-        bestHash = candidateHash;
-        store.markCandidate(candidateId, 'accepted', evalRes.result.weightedScore);
-        store.updateRun(runId, {
-          bestSkillHash: bestHash,
-          bestScore,
-          acceptedSteps: accepted,
-          rejectedSteps: rejected,
-          epochsCompleted: epoch,
-        });
-        log(`  ACCEPTED step ${cand.step}`);
-      } else {
-        rejected++;
-        store.markCandidate(candidateId, 'rejected', evalRes.result.weightedScore);
-        store.saveRejection({
-          runId,
-          candidateHash,
-          patches: applied,
-          reason: `delta ${delta.toFixed(3)} < threshold ${args.config.acceptThreshold}`,
-          deltaScore: delta,
-        });
-        store.updateRun(runId, {
-          rejectedSteps: rejected,
-          epochsCompleted: epoch,
-        });
-        log(`  REJECTED step ${cand.step}`);
-      }
+        const batches = makeMinibatches(trainTraj, args.config.batchSize, args.config.minibatches);
+        log(`epoch ${epoch}: ${batches.length} minibatch(es) of ~${args.config.batchSize}`);
 
-      if (args.config.slowUpdateEveryEpochs > 0 && epoch % args.config.slowUpdateEveryEpochs === 0) {
-        log(`  epoch boundary: running slow update`);
-        const slow = await runSlowUpdate({
-          bestSkill,
-          recentlyAcceptedDiffs: [],
-          acceptedTrajectories: trainTraj.slice(0, 12),
-          provider: args.config.optimizerProvider,
-          model: args.config.optimizerModel,
-        });
-        spent += slow.costUsd;
-        store.updateRun(runId, { spentUsd: spent });
-        if (slow.changed) {
-          const slowEval = await validateSkill({
-            skill: slow.skill,
-            items: validationItems,
-            provider: args.config.evaluatorProvider,
-            model: args.config.evaluatorModel,
+        const epochPatchBatches: Patch[][] = [];
+        for (let b = 0; b < batches.length; b++) {
+          if (!guardBudget(0.02, `reflect minibatch ${b + 1}`)) break;
+          const batchPatches = await reflect({
+            input: {
+              currentSkill: bestSkill,
+              trajectories: batches[b],
+              rejectedHistory: store.getRejections(runId, 10),
+              lrBudget: args.config.lrBudget,
+            },
+            provider: args.config.optimizerProvider,
+            model: args.config.optimizerModel,
           });
-          spent += slowEval.costUsd;
-          if (slowEval.result.weightedScore >= bestScore) {
-            bestSkill = slow.skill;
-            bestScore = slowEval.result.weightedScore;
-            bestHash = skillHash(bestSkill);
-            store.updateRun(runId, { bestSkillHash: bestHash, bestScore, spentUsd: spent });
-            log(`  slow update ACCEPTED (score ${bestScore.toFixed(3)})`);
-          } else {
-            log(`  slow update rejected (score ${slowEval.result.weightedScore.toFixed(3)} < ${bestScore.toFixed(3)})`);
-            store.updateRun(runId, { spentUsd: spent });
+          spent += batchPatches.costUsd;
+          store.updateRun(runId, { spentUsd: spent });
+          epochPatchBatches.push(batchPatches.patches);
+          log(`  minibatch ${b + 1}/${batches.length}: ${batchPatches.patches.length} raw patches (spent $${spent.toFixed(3)})`);
+        }
+
+        const aggregated = aggregatePatches(epochPatchBatches);
+        const clipped = clipByLR(aggregated.merged, args.config.lrBudget);
+        if (clipped.selected.length === 0) {
+          log(`  no patches selected; continuing`);
+          continue;
+        }
+
+        const { content: candContent, applied, skipped } = applyPatches(bestSkill, clipped.selected);
+        const candidateHash = skillHash(candContent);
+        if (candidateHash === bestHash) {
+          log(`  candidate identical to best after apply; skipping`);
+          continue;
+        }
+        if (candidateTokens(candContent) > args.config.maxSkillTokens) {
+          log(`  candidate exceeds maxSkillTokens (${args.config.maxSkillTokens}); rejecting`);
+          rejected++;
+          store.saveRejection({
+            runId,
+            candidateHash,
+            patches: applied,
+            reason: 'exceeds_max_tokens',
+            deltaScore: null,
+          });
+          continue;
+        }
+
+        const cand: Omit<Candidate, 'id'> = {
+          runId,
+          parentHash: bestHash,
+          contentHash: candidateHash,
+          content: candContent,
+          sourcePatches: applied,
+          step: accepted + rejected + 1,
+          epoch,
+          status: 'pending',
+        };
+        const candidateId = store.saveCandidate(cand);
+        store.recordPatches(runId, candidateId, cand.step, epoch, applied, 'applied');
+        if (skipped.length > 0) {
+          store.rejectPatches(runId, candidateId, cand.step, epoch, skipped.map((s) => s.patch), 'anchor_missing');
+        }
+
+        if (!guardBudget(0.01, `evaluate step ${cand.step}`)) break;
+        const evalRes = await validateSkill({
+          skill: candContent,
+          items: validationItems,
+          provider: args.config.evaluatorProvider,
+          model: args.config.evaluatorModel,
+        });
+        spent += evalRes.costUsd;
+        store.updateRun(runId, { spentUsd: spent });
+
+        const delta = evalRes.result.weightedScore - bestScore;
+        log(`  candidate score=${evalRes.result.weightedScore.toFixed(3)} (delta=${delta >= 0 ? '+' : ''}${delta.toFixed(3)})`);
+
+        if (delta >= args.config.acceptThreshold) {
+          accepted++;
+          recentlyAcceptedDiffs.push(summarizeDiff(bestSkill, candContent, applied));
+          bestSkill = candContent;
+          bestScore = evalRes.result.weightedScore;
+          bestHash = candidateHash;
+          store.markCandidate(candidateId, 'accepted', evalRes.result.weightedScore);
+          store.updateRun(runId, {
+            bestSkillHash: bestHash,
+            bestScore,
+            acceptedSteps: accepted,
+            rejectedSteps: rejected,
+            epochsCompleted: epoch,
+          });
+          log(`  ACCEPTED step ${cand.step}`);
+        } else {
+          rejected++;
+          store.markCandidate(candidateId, 'rejected', evalRes.result.weightedScore);
+          store.saveRejection({
+            runId,
+            candidateHash,
+            patches: applied,
+            reason: `delta ${delta.toFixed(3)} < threshold ${args.config.acceptThreshold}`,
+            deltaScore: delta,
+          });
+          store.updateRun(runId, { rejectedSteps: rejected, epochsCompleted: epoch });
+          log(`  REJECTED step ${cand.step}`);
+        }
+
+        if (args.config.slowUpdateEveryEpochs > 0 && epoch % args.config.slowUpdateEveryEpochs === 0) {
+          if (!guardBudget(0.05, 'slow update')) break;
+          log(`  epoch boundary: running slow update`);
+          const slow = await runSlowUpdate({
+            bestSkill,
+            recentlyAcceptedDiffs: recentlyAcceptedDiffs.slice(-8),
+            acceptedTrajectories: trainTraj.slice(0, 12),
+            provider: args.config.optimizerProvider,
+            model: args.config.optimizerModel,
+          });
+          spent += slow.costUsd;
+          store.updateRun(runId, { spentUsd: spent });
+          if (slow.changed) {
+            if (!guardBudget(0.01, 'slow update eval')) break;
+            const slowEval = await validateSkill({
+              skill: slow.skill,
+              items: validationItems,
+              provider: args.config.evaluatorProvider,
+              model: args.config.evaluatorModel,
+            });
+            spent += slowEval.costUsd;
+            const slowDelta = slowEval.result.weightedScore - bestScore;
+            if (slowDelta >= args.config.acceptThreshold) {
+              bestSkill = slow.skill;
+              bestScore = slowEval.result.weightedScore;
+              bestHash = skillHash(bestSkill);
+              store.updateRun(runId, { bestSkillHash: bestHash, bestScore, spentUsd: spent });
+              log(`  slow update ACCEPTED (score ${bestScore.toFixed(3)})`);
+            } else {
+              log(`  slow update rejected (delta ${slowDelta.toFixed(3)} < threshold ${args.config.acceptThreshold})`);
+              store.updateRun(runId, { spentUsd: spent });
+            }
           }
         }
       }
+
+      writeBestSkill(args.skillPath, bestSkill, bestHash, args.skillSlug);
+      flushAndEnd('completed', stoppedReason);
+      return outcome(runId, bestSkill, bestHash, bestScore, initialScoreValue, epoch - 1, accepted, rejected, spent, stoppedReason);
+    } catch (err) {
+      flushAndEnd('failed', (err as Error).message ?? 'unknown error');
+      throw err;
     }
-
-    writeBestSkill(args.skillPath, bestSkill, bestHash, args.skillSlug);
-    store.endRun(runId, 'completed', stoppedReason);
-
-    return {
-      runId,
-      bestSkill,
-      bestSkillHash: bestHash,
-      bestScore,
-      initialScore: initialEval.result.weightedScore,
-      epochsCompleted: epoch - 1,
-      acceptedSteps: accepted,
-      rejectedSteps: rejected,
-      spentUsd: spent,
-      stoppedReason,
-    };
   } finally {
     if (ownStore) store.close();
   }
+}
+
+function outcome(
+  runId: number,
+  bestSkill: string,
+  bestSkillHash: string,
+  bestScore: number,
+  initialScore: number,
+  epochsCompleted: number,
+  acceptedSteps: number,
+  rejectedSteps: number,
+  spentUsd: number,
+  stoppedReason: string,
+): TrainerOutcome {
+  return {
+    runId,
+    bestSkill,
+    bestSkillHash,
+    bestScore,
+    initialScore,
+    epochsCompleted,
+    acceptedSteps,
+    rejectedSteps,
+    spentUsd,
+    stoppedReason,
+  };
 }
 
 function makeMinibatches(traj: Trajectory[], batchSize: number, count: number): Trajectory[][] {
@@ -278,7 +325,18 @@ function candidateTokens(s: string): number {
   return Math.ceil(s.length / 3.5);
 }
 
+function summarizeDiff(before: string, after: string, applied: Patch[]): string {
+  const beforeLen = before.length;
+  const afterLen = after.length;
+  return `step len ${beforeLen}->${afterLen} (${applied.length} patches: ${applied.map((p) => p.op).join(',')})`;
+}
+
+export function stripExistingStamp(content: string): string {
+  return content.replace(STAMP_RE, '');
+}
+
 function writeBestSkill(path: string, content: string, hash: string, slug: string): void {
+  const cleaned = stripExistingStamp(content).replace(/\s+$/, '');
   const stamp = `<!-- skill-optimizer: hash=${hash} slug=${slug} -->\n`;
-  writeFileSync(path, content.endsWith('\n') ? content + stamp : content + '\n' + stamp, 'utf8');
+  writeFileSync(path, cleaned + '\n' + stamp, 'utf8');
 }

--- a/src/optimizer/trainer.ts
+++ b/src/optimizer/trainer.ts
@@ -1,0 +1,284 @@
+import { aggregatePatches } from './aggregate';
+import { applyPatches } from './apply';
+import { clipByLR } from './clip';
+import { skillHash } from './hash';
+import { reflect } from './reflect';
+import { runSlowUpdate } from './slow';
+import { validateSkill } from './validate';
+import { createOptimizerStore, trajectoriesToValidation, type OptimizerStore } from './store';
+import type {
+  Candidate,
+  OptimizationRun,
+  Patch,
+  TrainerConfig,
+  Trajectory,
+  ValidationItem,
+} from './types';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+export interface TrainerArgs {
+  skillSlug: string;
+  skillPath: string;
+  config: TrainerConfig;
+  trajectoryLimit?: number;
+  logger?: (line: string) => void;
+  store?: OptimizerStore;
+}
+
+export interface TrainerOutcome {
+  runId: number;
+  bestSkill: string;
+  bestSkillHash: string;
+  bestScore: number;
+  initialScore: number;
+  epochsCompleted: number;
+  acceptedSteps: number;
+  rejectedSteps: number;
+  spentUsd: number;
+  stoppedReason: string;
+}
+
+export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
+  const log = args.logger ?? ((line: string) => process.stderr.write(`[skill-optimizer] ${line}\n`));
+  const store = args.store ?? createOptimizerStore();
+  let ownStore = !args.store;
+
+  try {
+    const initialSkill = readFileSync(args.skillPath, 'utf8');
+    const initialHash = skillHash(initialSkill);
+
+    const trajectories = store.collectTrajectories(args.skillSlug, args.trajectoryLimit ?? 200);
+    if (trajectories.length < 8) {
+      throw new Error(`only ${trajectories.length} trajectories for "${args.skillSlug}"; need >= 8`);
+    }
+
+    const { train: trainTraj, validation: valSeeds } = trajectoriesToValidation(
+      args.skillSlug,
+      trajectories,
+      args.config.validationHoldout,
+    );
+    store.upsertValidation(args.skillSlug, valSeeds);
+    const validationItems = store.listValidation(args.skillSlug);
+    log(`trajectories: train=${trainTraj.length} validation=${validationItems.length}`);
+
+    const runId = store.createRun({
+      skillSlug: args.skillSlug,
+      status: 'running',
+      initialSkillHash: initialHash,
+      bestSkillHash: initialHash,
+      initialScore: null,
+      bestScore: null,
+      epochsCompleted: 0,
+      acceptedSteps: 0,
+      rejectedSteps: 0,
+      budgetUsd: args.config.budgetUsd,
+      spentUsd: 0,
+      config: args.config,
+      reason: null,
+    });
+
+    const initialEval = await validateSkill({
+      skill: initialSkill,
+      items: validationItems,
+      provider: args.config.evaluatorProvider,
+      model: args.config.evaluatorModel,
+    });
+    let spent = initialEval.costUsd;
+    let bestSkill = initialSkill;
+    let bestScore = initialEval.result.weightedScore;
+    let bestHash = initialHash;
+    store.updateRun(runId, { initialScore: bestScore, bestScore });
+    log(`baseline: score=${bestScore.toFixed(3)} (${initialEval.result.passed}/${initialEval.result.total})`);
+
+    let accepted = 0;
+    let rejected = 0;
+    let epoch = 0;
+    let stoppedReason = 'completed';
+
+    for (epoch = 1; epoch <= args.config.epochs; epoch++) {
+      if (existsSync(args.config.killSwitchPath)) {
+        stoppedReason = `kill-switch ${args.config.killSwitchPath}`;
+        break;
+      }
+      if (spent >= args.config.budgetUsd) {
+        stoppedReason = `budget exhausted at $${spent.toFixed(2)}`;
+        break;
+      }
+
+      const batches = makeMinibatches(trainTraj, args.config.batchSize, args.config.minibatches);
+      log(`epoch ${epoch}: ${batches.length} minibatch(es) of ~${args.config.batchSize}`);
+
+      const epochPatchBatches: Patch[][] = [];
+      for (let b = 0; b < batches.length; b++) {
+        const batchPatches = await reflect({
+          input: {
+            currentSkill: bestSkill,
+            trajectories: batches[b],
+            rejectedHistory: store.getRejections(runId, 10),
+            lrBudget: args.config.lrBudget,
+          },
+          provider: args.config.optimizerProvider,
+          model: args.config.optimizerModel,
+        });
+        spent += batchPatches.costUsd;
+        store.updateRun(runId, { spentUsd: spent });
+        epochPatchBatches.push(batchPatches.patches);
+        log(`  minibatch ${b + 1}/${batches.length}: ${batchPatches.patches.length} raw patches (spent $${spent.toFixed(3)})`);
+        if (spent >= args.config.budgetUsd) break;
+      }
+
+      const aggregated = aggregatePatches(epochPatchBatches);
+      const clipped = clipByLR(aggregated.merged, args.config.lrBudget);
+      if (clipped.selected.length === 0) {
+        log(`  no patches selected; continuing`);
+        continue;
+      }
+
+      const { content: candContent, applied, skipped } = applyPatches(bestSkill, clipped.selected);
+      const candidateHash = skillHash(candContent);
+      if (candidateHash === bestHash) {
+        log(`  candidate identical to best after apply; skipping`);
+        continue;
+      }
+      if (candidateTokens(candContent) > args.config.maxSkillTokens) {
+        log(`  candidate exceeds maxSkillTokens (${args.config.maxSkillTokens}); rejecting`);
+        rejected++;
+        store.saveRejection({
+          runId,
+          candidateHash,
+          patches: applied,
+          reason: 'exceeds_max_tokens',
+          deltaScore: null,
+        });
+        continue;
+      }
+
+      const cand: Omit<Candidate, 'id'> = {
+        runId,
+        parentHash: bestHash,
+        contentHash: candidateHash,
+        content: candContent,
+        sourcePatches: applied,
+        step: accepted + rejected + 1,
+        epoch,
+        status: 'pending',
+      };
+      const candidateId = store.saveCandidate(cand);
+      store.recordPatches(runId, candidateId, cand.step, epoch, applied, 'applied');
+      if (skipped.length > 0) {
+        store.rejectPatches(runId, candidateId, cand.step, epoch, skipped.map((s) => s.patch), 'anchor_missing');
+      }
+
+      const evalRes = await validateSkill({
+        skill: candContent,
+        items: validationItems,
+        provider: args.config.evaluatorProvider,
+        model: args.config.evaluatorModel,
+      });
+      spent += evalRes.costUsd;
+      store.updateRun(runId, { spentUsd: spent });
+
+      const delta = evalRes.result.weightedScore - bestScore;
+      log(`  candidate score=${evalRes.result.weightedScore.toFixed(3)} (delta=${delta >= 0 ? '+' : ''}${delta.toFixed(3)})`);
+
+      if (delta >= args.config.acceptThreshold) {
+        accepted++;
+        bestSkill = candContent;
+        bestScore = evalRes.result.weightedScore;
+        bestHash = candidateHash;
+        store.markCandidate(candidateId, 'accepted', evalRes.result.weightedScore);
+        store.updateRun(runId, {
+          bestSkillHash: bestHash,
+          bestScore,
+          acceptedSteps: accepted,
+          rejectedSteps: rejected,
+          epochsCompleted: epoch,
+        });
+        log(`  ACCEPTED step ${cand.step}`);
+      } else {
+        rejected++;
+        store.markCandidate(candidateId, 'rejected', evalRes.result.weightedScore);
+        store.saveRejection({
+          runId,
+          candidateHash,
+          patches: applied,
+          reason: `delta ${delta.toFixed(3)} < threshold ${args.config.acceptThreshold}`,
+          deltaScore: delta,
+        });
+        store.updateRun(runId, {
+          rejectedSteps: rejected,
+          epochsCompleted: epoch,
+        });
+        log(`  REJECTED step ${cand.step}`);
+      }
+
+      if (args.config.slowUpdateEveryEpochs > 0 && epoch % args.config.slowUpdateEveryEpochs === 0) {
+        log(`  epoch boundary: running slow update`);
+        const slow = await runSlowUpdate({
+          bestSkill,
+          recentlyAcceptedDiffs: [],
+          acceptedTrajectories: trainTraj.slice(0, 12),
+          provider: args.config.optimizerProvider,
+          model: args.config.optimizerModel,
+        });
+        spent += slow.costUsd;
+        store.updateRun(runId, { spentUsd: spent });
+        if (slow.changed) {
+          const slowEval = await validateSkill({
+            skill: slow.skill,
+            items: validationItems,
+            provider: args.config.evaluatorProvider,
+            model: args.config.evaluatorModel,
+          });
+          spent += slowEval.costUsd;
+          if (slowEval.result.weightedScore >= bestScore) {
+            bestSkill = slow.skill;
+            bestScore = slowEval.result.weightedScore;
+            bestHash = skillHash(bestSkill);
+            store.updateRun(runId, { bestSkillHash: bestHash, bestScore, spentUsd: spent });
+            log(`  slow update ACCEPTED (score ${bestScore.toFixed(3)})`);
+          } else {
+            log(`  slow update rejected (score ${slowEval.result.weightedScore.toFixed(3)} < ${bestScore.toFixed(3)})`);
+            store.updateRun(runId, { spentUsd: spent });
+          }
+        }
+      }
+    }
+
+    writeBestSkill(args.skillPath, bestSkill, bestHash, args.skillSlug);
+    store.endRun(runId, 'completed', stoppedReason);
+
+    return {
+      runId,
+      bestSkill,
+      bestSkillHash: bestHash,
+      bestScore,
+      initialScore: initialEval.result.weightedScore,
+      epochsCompleted: epoch - 1,
+      acceptedSteps: accepted,
+      rejectedSteps: rejected,
+      spentUsd: spent,
+      stoppedReason,
+    };
+  } finally {
+    if (ownStore) store.close();
+  }
+}
+
+function makeMinibatches(traj: Trajectory[], batchSize: number, count: number): Trajectory[][] {
+  const out: Trajectory[][] = [];
+  for (let i = 0; i < count; i++) {
+    const shuffled = [...traj].sort(() => Math.random() - 0.5);
+    out.push(shuffled.slice(0, batchSize));
+  }
+  return out;
+}
+
+function candidateTokens(s: string): number {
+  return Math.ceil(s.length / 3.5);
+}
+
+function writeBestSkill(path: string, content: string, hash: string, slug: string): void {
+  const stamp = `<!-- skill-optimizer: hash=${hash} slug=${slug} -->\n`;
+  writeFileSync(path, content.endsWith('\n') ? content + stamp : content + '\n' + stamp, 'utf8');
+}

--- a/src/optimizer/trainer.ts
+++ b/src/optimizer/trainer.ts
@@ -9,7 +9,7 @@ import { createOptimizerStore, trajectoriesToValidation, type OptimizerStore } f
 import type { Candidate, Patch, TrainerConfig, Trajectory } from './types';
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 
-const STAMP_RE = /\n?<!-- skill-optimizer: [^>]*-->\s*$/g;
+const STAMP_RE = /\n?<!-- skill-optimizer: [^>]*-->\s*/g;
 
 export interface TrainerArgs {
   skillSlug: string;
@@ -54,6 +54,12 @@ export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
     );
     store.upsertValidation(args.skillSlug, valSeeds);
     const validationItems = store.listValidation(args.skillSlug);
+    if (validationItems.length < 2) {
+      throw new Error(
+        `validation set too small (${validationItems.length} items). ` +
+        `Need at least 2; increase --holdout or accumulate more learn-rule rows.`,
+      );
+    }
     log(`trajectories: train=${trainTraj.length} validation=${validationItems.length}`);
 
     const runId = store.createRun({
@@ -180,13 +186,16 @@ export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
           continue;
         }
 
+        const candStep = accepted + rejected + 1;
+        if (!guardBudget(0.01, `evaluate step ${candStep}`)) break;
+
         const cand: Omit<Candidate, 'id'> = {
           runId,
           parentHash: bestHash,
           contentHash: candidateHash,
           content: candContent,
           sourcePatches: applied,
-          step: accepted + rejected + 1,
+          step: candStep,
           epoch,
           status: 'pending',
         };
@@ -196,7 +205,6 @@ export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
           store.rejectPatches(runId, candidateId, cand.step, epoch, skipped.map((s) => s.patch), 'anchor_missing');
         }
 
-        if (!guardBudget(0.01, `evaluate step ${cand.step}`)) break;
         const evalRes = await validateSkill({
           skill: candContent,
           items: validationItems,
@@ -274,7 +282,11 @@ export async function train(args: TrainerArgs): Promise<TrainerOutcome> {
         }
       }
 
-      writeBestSkill(args.skillPath, bestSkill, bestHash, args.skillSlug);
+      if (bestHash !== initialHash) {
+        writeBestSkill(args.skillPath, bestSkill, bestHash, args.skillSlug);
+      } else {
+        log(`no candidate beat baseline; SKILL.md left untouched`);
+      }
       flushAndEnd('completed', stoppedReason);
       return outcome(runId, bestSkill, bestHash, bestScore, initialScoreValue, epoch - 1, accepted, rejected, spent, stoppedReason);
     } catch (err) {
@@ -315,10 +327,18 @@ function outcome(
 function makeMinibatches(traj: Trajectory[], batchSize: number, count: number): Trajectory[][] {
   const out: Trajectory[][] = [];
   for (let i = 0; i < count; i++) {
-    const shuffled = [...traj].sort(() => Math.random() - 0.5);
+    const shuffled = fisherYatesShuffle([...traj]);
     out.push(shuffled.slice(0, batchSize));
   }
   return out;
+}
+
+function fisherYatesShuffle<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
 }
 
 function candidateTokens(s: string): number {

--- a/src/optimizer/types.ts
+++ b/src/optimizer/types.ts
@@ -1,0 +1,115 @@
+export type PatchOp = 'add' | 'delete' | 'replace';
+
+export interface Patch {
+  op: PatchOp;
+  anchor: string;
+  payload: string;
+}
+
+export interface Trajectory {
+  learningId: number;
+  category: string;
+  rule: string;
+  mistake: string | null;
+  correction: string | null;
+  timesApplied: number;
+  createdAt: string;
+}
+
+export interface ValidationItem {
+  id: number;
+  skillSlug: string;
+  prompt: string;
+  expected: string;
+  weight: number;
+  frozenAt: string;
+}
+
+export interface ValidationOutcome {
+  itemId: number;
+  pass: boolean;
+  score: number;
+  rationale: string;
+}
+
+export interface ValidationResult {
+  total: number;
+  passed: number;
+  weightedScore: number;
+  outcomes: ValidationOutcome[];
+}
+
+export interface Candidate {
+  id?: number;
+  runId: number;
+  parentHash: string;
+  contentHash: string;
+  content: string;
+  sourcePatches: Patch[];
+  step: number;
+  epoch: number;
+  score?: number;
+  status: 'pending' | 'accepted' | 'rejected';
+}
+
+export interface OptimizationRun {
+  id?: number;
+  skillSlug: string;
+  status: 'running' | 'completed' | 'failed' | 'stopped';
+  initialSkillHash: string;
+  bestSkillHash: string | null;
+  initialScore: number | null;
+  bestScore: number | null;
+  epochsCompleted: number;
+  acceptedSteps: number;
+  rejectedSteps: number;
+  budgetUsd: number;
+  spentUsd: number;
+  config: TrainerConfig;
+  reason: string | null;
+}
+
+export interface TrainerConfig {
+  epochs: number;
+  batchSize: number;
+  minibatches: number;
+  lrBudget: LRBudget;
+  validationHoldout: number;
+  budgetUsd: number;
+  optimizerModel: string;
+  optimizerProvider: 'anthropic' | 'openai' | 'openrouter' | 'fireworks';
+  evaluatorModel: string;
+  evaluatorProvider: 'anthropic' | 'openai' | 'openrouter' | 'fireworks';
+  slowUpdateEveryEpochs: number;
+  metaUpdateEveryEpochs: number;
+  acceptThreshold: number;
+  maxSkillTokens: number;
+  killSwitchPath: string;
+}
+
+export interface LRBudget {
+  maxAdds: number;
+  maxDeletes: number;
+  maxReplaces: number;
+}
+
+export interface Rejection {
+  runId: number;
+  candidateHash: string;
+  patches: Patch[];
+  reason: string;
+  deltaScore: number | null;
+}
+
+export interface ReflectInput {
+  currentSkill: string;
+  trajectories: Trajectory[];
+  rejectedHistory: Rejection[];
+  lrBudget: LRBudget;
+}
+
+export interface ReflectOutput {
+  patches: Patch[];
+  reasoning: string;
+  costUsd: number;
+}

--- a/src/optimizer/validate.ts
+++ b/src/optimizer/validate.ts
@@ -1,0 +1,78 @@
+import type { ValidationItem, ValidationOutcome, ValidationResult } from './types';
+import { callLLM, type Provider } from './llm';
+
+export interface ValidateArgs {
+  skill: string;
+  items: ValidationItem[];
+  provider: Provider;
+  model: string;
+}
+
+export interface ValidateLLMRunResult {
+  result: ValidationResult;
+  costUsd: number;
+}
+
+export async function validateSkill({ skill, items, provider, model }: ValidateArgs): Promise<ValidateLLMRunResult> {
+  if (items.length === 0) {
+    return { result: { total: 0, passed: 0, weightedScore: 0, outcomes: [] }, costUsd: 0 };
+  }
+
+  const system = SYSTEM_PROMPT;
+  const user = JSON.stringify({
+    candidate_skill: skill,
+    validation_items: items.map((i) => ({ id: i.id, prompt: i.prompt, expected: i.expected, weight: i.weight })),
+  });
+
+  const res = await callLLM({ provider, model, system, user, maxTokens: 4096, temperature: 0 });
+  const outcomes = parseOutcomes(res.text);
+  const passedItems = outcomes.filter((o) => o.pass);
+  const passedWeight = passedItems.reduce((acc, o) => acc + (items.find((i) => i.id === o.itemId)?.weight ?? 0), 0);
+  const totalWeight = items.reduce((acc, i) => acc + i.weight, 0);
+  const weightedScore = totalWeight === 0 ? 0 : passedWeight / totalWeight;
+
+  return {
+    result: { total: items.length, passed: passedItems.length, weightedScore, outcomes },
+    costUsd: res.costUsd,
+  };
+}
+
+const SYSTEM_PROMPT = `You are an evaluation gate. For each validation item, decide whether the candidate skill content would lead an agent to satisfy the expected behavior on the prompt.
+
+Output STRICT JSON only, no prose, no markdown fences. Schema:
+{
+  "outcomes": [
+    { "item_id": <int>, "pass": <bool>, "score": <float 0..1>, "rationale": "<one sentence>" }
+  ]
+}
+
+Rules:
+- pass=true only if a competent agent following the skill content would produce the expected behavior on the prompt.
+- score is your continuous confidence: 1.0 = perfect, 0.0 = clearly violates.
+- Be strict: borderline cases score below 0.6 and pass=false.`;
+
+function parseOutcomes(text: string): ValidationOutcome[] {
+  const stripped = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
+  let obj: unknown;
+  try {
+    obj = JSON.parse(stripped);
+  } catch {
+    return [];
+  }
+  const root = obj as { outcomes?: unknown };
+  if (!Array.isArray(root.outcomes)) return [];
+  const out: ValidationOutcome[] = [];
+  for (const raw of root.outcomes) {
+    const o = raw as Record<string, unknown>;
+    if (typeof o.item_id !== 'number' || typeof o.pass !== 'boolean') continue;
+    out.push({
+      itemId: o.item_id,
+      pass: o.pass,
+      score: typeof o.score === 'number' ? o.score : o.pass ? 1 : 0,
+      rationale: typeof o.rationale === 'string' ? o.rationale : '',
+    });
+  }
+  return out;
+}
+
+export const __test = { parseOutcomes };

--- a/src/optimizer/validate.ts
+++ b/src/optimizer/validate.ts
@@ -1,5 +1,6 @@
 import type { ValidationItem, ValidationOutcome, ValidationResult } from './types';
 import { callLLM, type Provider } from './llm';
+import { stripFencesAndParse } from './parse';
 
 export interface ValidateArgs {
   skill: string;
@@ -52,15 +53,8 @@ Rules:
 - Be strict: borderline cases score below 0.6 and pass=false.`;
 
 function parseOutcomes(text: string): ValidationOutcome[] {
-  const stripped = text.replace(/^```(?:json)?\s*\n?/, '').replace(/\n?```\s*$/, '').trim();
-  let obj: unknown;
-  try {
-    obj = JSON.parse(stripped);
-  } catch {
-    return [];
-  }
-  const root = obj as { outcomes?: unknown };
-  if (!Array.isArray(root.outcomes)) return [];
+  const root = stripFencesAndParse<{ outcomes?: unknown }>(text);
+  if (!root || !Array.isArray(root.outcomes)) return [];
   const out: ValidationOutcome[] = [];
   for (const raw of root.outcomes) {
     const o = raw as Record<string, unknown>;


### PR DESCRIPTION
Implements the bridge sketched in [the SkillOpt analysis](#) — treat learn-rule outputs as training trajectories, run a budget-capped offline optimization over each skill's SKILL.md, gate by validation set of past corrections.

## What it does

A new `/skill-optimize <slug>` command runs a 6-stage pipeline borrowed from Microsoft SkillOpt's ReflACT loop, adapted to pro-workflow's existing SQLite + learnings tables:

```
rollout   -> existing learn-rule rows for the slug
reflect   -> optimizer LLM proposes bounded add/delete/replace patches
aggregate -> vote-merge patches across minibatches
select    -> clip by LR budget (default: 3 adds, 2 deletes, 3 replaces per step)
update    -> apply patches deterministically to a candidate
evaluate  -> evaluator LLM scores candidate against frozen validation holdout
gate      -> accept candidate only when delta >= acceptThreshold
```

Rejected candidates feed a rejection buffer that biases the next reflect step. At epoch boundaries a slow-update consolidation rewrites the best skill; the rewrite itself must pass the gate.

## Files

```
src/optimizer/
  types.ts        Patch, Trajectory, ValidationItem, TrainerConfig, ...
  hash.ts         16-char sha256 skill hash
  apply.ts        deterministic patch application (add/delete/replace)
  aggregate.ts    vote-merge with op ordering
  clip.ts         LR-budget enforcement
  llm.ts          provider dispatch (anthropic/openai/openrouter/fireworks)
  reflect.ts      reflect-step LLM call + JSON parse
  validate.ts     gate LLM call + weighted scoring
  slow.ts         slow-update consolidation
  store.ts        DB layer for the 5 new tables + train/val split helper
  trainer.ts      orchestrator (epoch loop, kill switch, budget cap)
  __tests__/      9 node:test cases for the pure layer

scripts/optimize-skill.js     CLI entry, --json mode, kill-switch aware
skills/skill-optimizer/SKILL.md
commands/skill-optimize.md
src/db/schema.sql             +5 tables (runs, candidates, patches, validation, rejections)
```

## Configuration

| Flag | Default | |
|---|---|---|
| `--epochs N` | 3 | outer loop |
| `--batch-size N` | 8 | trajectories per minibatch |
| `--minibatches N` | 2 | per epoch |
| `--holdout N` | 6 | validation reserved (capped at 25% of trajectories) |
| `--budget-usd X` | 0.50 | hard cap; abort on exhaust |
| `--optimizer-model M` | `claude-sonnet-4-6` | reflect + slow |
| `--evaluator-model M` | `claude-haiku-4-5-20251001` | gate (cheaper) |
| `--max-adds / --max-deletes / --max-replaces` | 3 / 2 / 3 | per-step LR budget |
| `--accept-threshold X` | 0.0 | minimum delta |
| `--max-skill-tokens N` | 2000 | candidate length cap |
| `--slow-every N` | 2 | epochs between consolidation |

Kill switch: `touch ~/.pro-workflow/STOP`.

## Provenance

Inspired by Microsoft SkillOpt (arXiv:2605.23904). The 6-stage pipeline, LR budget, rejection buffer, and slow / meta update mechanics are adapted to pro-workflow's data plane. No SkillOpt code reused; this is an independent port of the concepts in TypeScript on top of `better-sqlite3`.

## Test plan

- [x] Pure layer (apply / aggregate / clip): 9 node:test cases via `npm test`
- [x] Build: `npm run build` clean
- [x] CLI no-arg: prints usage and exits 1
- [x] CLI bad slug: prints "SKILL.md not found" and exits 1
- [x] CLI low trajectories: errors with `only N trajectories; need >= 8`
- [ ] Reviewer: end-to-end with `ANTHROPIC_API_KEY` against a real skill (requires API spend; defaults cap at $0.50)
- [ ] Reviewer: verify SQLite schema migrates cleanly on existing `~/.pro-workflow/data.db`

## Out of scope

- Meta-update (epoch-of-epochs deeper consolidation): config flag exists, hook is wired but the implementation defers to a follow-up
- Multi-provider mixing within a single run: optimizer and evaluator can already be different models from the same provider; cross-provider works but is untested
- A real per-skill validation seed UI: validation rows are currently auto-derived from the longest-applied trajectories on first run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added /skill-optimize command and CLI for offline, budget‑capped skill training with optional JSON output, kill‑switch, validation holdout, slow‑update consolidation, and automatic overwrite of a skill when an improved candidate is found.

* **Chores**
  * Version bumped to 3.4.0 and added a npm test script for optimizer tests.

* **Tests**
  * Expanded optimizer test coverage for patching, aggregation, clipping, stamping, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->