### PR TITLE
fix(commit-validate): handle heredoc inside -m command substitution

### DIFF
--- a/scripts/commit-validate.js
+++ b/scripts/commit-validate.js
@@ -15,6 +15,15 @@ function readStdin() {
 function extractMessage(command) {
   if (!command) return { msg: null, form: 'empty' };
 
+  // Match bash heredoc: <<[-] [quote]DELIM[quote] \n body \n DELIM
+  // Group 1: optional opening quote (' or "), Group 2: delimiter name, Group 3: body.
+  // Closing delimiter is always bare (unquoted) per bash semantics.
+  const heredocAny = command.match(/<<-?\s*(['"]?)([A-Za-z_][A-Za-z0-9_]*)\1\s*\n([\s\S]*?)\n\s*\2\s*$/m);
+  if (heredocAny) {
+    const body = heredocAny[3].replace(/^\s*\n/, '');
+    return { msg: body, form: 'heredoc' };
+  }
+
   const shortFlag = command.match(/(?:^|\s)-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
   if (shortFlag) {
     const raw = shortFlag[1] || shortFlag[2] || shortFlag[3] || '';
@@ -26,9 +35,6 @@ function extractMessage(command) {
     const raw = longFlag[1] || longFlag[2] || longFlag[3] || '';
     return { msg: raw.replace(/\\"/g, '"').replace(/\\'/g, "'"), form: '--message' };
   }
-
-  const heredocAny = command.match(/<<-?\s*'?([A-Za-z_][A-Za-z0-9_]*)'?\s*\n([\s\S]*?)\n\s*\1\s*$/m);
-  if (heredocAny) return { msg: heredocAny[2].split('\n')[0], form: 'heredoc' };
 
   if (/(?:^|\s)-F(?:\s+\S+|=\S+)/.test(command) || /--file(?:=|\s+)\S+/.test(command)) {
     return { msg: null, form: 'file' };


### PR DESCRIPTION
The -m flag regex matched first and captured the literal $(cat <<DELIM ... DELIM) string as the message, failing conventional commit validation. Reordered detection to check heredoc patterns before -m/--message flags so the heredoc body is used as the message when present.

When claude code tried to run idiomatic git commit:
```
● Bash(git commit -m "$(cat <<'EOF'
      fix(secret): stop pulp-server Secret churn from nondeterministic migration settings

      needsMigrationSetting iterated MigrationSettingsList as a map, whose
      range order Go randomizes per invocation. With RedirectToObjectStorage=true.
      <<truncated>>

      Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
      EOF
      )" && git status)
```

then it failed with error:
```
    Error: PreToolUse:Bash hook error: [node "${CLAUDE_PLUGIN_ROOT}/scripts/commit-validate.js"]: [pro-workflow] commit-validate: Commit message must follow conventional commits: 
     <type>(<scope>): <summary>. Valid types: feat, fix, refactor, test, docs, chore, perf, ci, style, build, revert.
```

This PR allows claude code to use multi-line `$(cat <<DELIM ... DELIM)` passed as heredoc commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commit message validation now correctly handles heredoc-style messages (including quoted delimiters). It captures the full multi-line body and trims a leading blank line, preventing valid messages that start with a blank line from being rejected. Validation behavior for determining the message’s first line remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->