### PR TITLE
fix(commit-validate): scope message parsing to the git commit itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "clean": "rm -rf dist",
     "prepublishOnly": "npm run build",
     "db:init": "node dist/db/index.js",
-    "test": "tsx --test src/optimizer/__tests__/*.test.ts"
+    "test": "npm run test:optimizer && npm run test:hooks",
+    "test:optimizer": "tsx --test src/optimizer/__tests__/*.test.ts",
+    "test:hooks": "node --test scripts/__tests__/commit-validate.test.js"
   },
   "keywords": [
     "claude-code",

--- a/scripts/__tests__/commit-validate.test.js
+++ b/scripts/__tests__/commit-validate.test.js
@@ -49,6 +49,8 @@ describe('commit-validate: commands that are not a git commit', () => {
     ['heredoc sent over ssh', "ssh host <<'EOF'\nuptime\nEOF"],
     ['the word commit only as grep input', 'git log --oneline -5 | grep commit'],
     ['a quoted mention of git commit', "echo 'git commit' && python -m pytest"],
+    ['an unquoted mention of git commit', 'echo git commit -m "bad message not conventional"'],
+    ['commit as an argument to another subcommand', 'git log commit -m "bad message not conventional"'],
   ];
 
   for (const [why, command] of cases) {
@@ -85,6 +87,8 @@ describe('commit-validate: still blocks invalid messages', () => {
     ['amend with a message', 'git commit --amend -m "bad message not conventional"'],
     ['--message= form', 'git commit --message="bad message not conventional"'],
     ['message supplied by heredoc', "git commit -F- <<'EOF'\nbad message not conventional\nEOF"],
+    // A heredoc body may contain shell separators; they must not truncate it.
+    ['heredoc message containing separators', "git commit -F- <<'EOF'\nbad message; not & conventional\nEOF"],
   ];
 
   for (const [why, command] of cases) {
@@ -100,6 +104,11 @@ describe('commit-validate: lets valid commits through', () => {
     ['message read from a file', 'git commit -F /tmp/msg.txt'],
     ['message written in the editor', 'git commit'],
     ['valid commit followed by another command', 'git commit -m "chore: bump" && python -m pytest'],
+    // The message comes from the editor here; the -m belongs to the chained
+    // command, so extraction must stop at the separator rather than read it.
+    ['editor commit chained before a -m command', 'git commit && python -m pytest'],
+    ['editor commit chained before a heredoc', "git commit && cat > f.py <<'EOF'\nimport json\nEOF"],
+    ['a message containing shell separators', 'git commit -m "fix(api): guard a & b; retry"'],
   ];
 
   for (const [why, command] of cases) {

--- a/scripts/__tests__/commit-validate.test.js
+++ b/scripts/__tests__/commit-validate.test.js
@@ -1,0 +1,117 @@
+'use strict';
+// Contract tests for scripts/commit-validate.js.
+//
+// The hook's real contract is a process contract, not a function one: Claude Code
+// pipes a PreToolUse JSON payload on stdin and reads the exit code, where 2 blocks
+// the Bash call and 0 lets it through. These tests drive the script exactly that
+// way, so they cover the wiring (stdin parsing, exit codes) as well as the regexes.
+//
+// Two failure directions matter, and they pull against each other:
+//   * blocking a command that is not a commit at all  -> the hook eats unrelated work
+//   * failing to block a bad message                  -> the hook silently stops working
+// Every guard added here must keep the "still blocks" cases red-if-broken, otherwise
+// a false-positive fix can quietly turn validation off instead of narrowing it.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const path = require('node:path');
+
+const SCRIPT = path.join(__dirname, '..', 'commit-validate.js');
+const LONG_SUMMARY = 'x'.repeat(80); // > MAX_SUMMARY (72)
+
+function runHook(command) {
+  const res = spawnSync(process.execPath, [SCRIPT], {
+    input: JSON.stringify({ tool_input: { command } }),
+    encoding: 'utf8',
+  });
+  return { code: res.status, stderr: res.stderr || '' };
+}
+
+function assertAllows(command, why) {
+  const { code, stderr } = runHook(command);
+  assert.strictEqual(code, 0, `expected exit 0 (allow) for ${why}\ncommand: ${command}\nstderr: ${stderr}`);
+}
+
+function assertBlocks(command, why) {
+  const { code } = runHook(command);
+  assert.strictEqual(code, 2, `expected exit 2 (block) for ${why}\ncommand: ${command}`);
+}
+
+describe('commit-validate: commands that are not a git commit', () => {
+  const cases = [
+    ['unrelated -m flag on a python module', 'python -m pytest tests/ -q'],
+    ['-m flag nested in a docker invocation', 'docker compose run --rm -T web python -m ruff check .'],
+    ['-m flag passed through npm', 'npm run build -- -m foo'],
+    ['heredoc writing a file', "cat > file.py <<'EOF'\nimport json\nEOF"],
+    ['heredoc piped into an interpreter', "python3 - <<'PY'\nprint('hello')\nPY"],
+    ['heredoc piped into psql', "psql -U u -d d <<'SQL'\nSELECT 1;\nSQL"],
+    ['heredoc sent over ssh', "ssh host <<'EOF'\nuptime\nEOF"],
+    ['the word commit only as grep input', 'git log --oneline -5 | grep commit'],
+    ['a quoted mention of git commit', "echo 'git commit' && python -m pytest"],
+  ];
+
+  for (const [why, command] of cases) {
+    test(`allows ${why}`, () => assertAllows(command, why));
+  }
+});
+
+describe('commit-validate: a real commit preceded by an unrelated -m', () => {
+  // Regression guard: the message must be read from after the `commit` verb.
+  // Scanning the whole command line picks up the earlier flag's value instead
+  // (`pytest`, `ruff`), which fails validation and blocks a perfectly good commit.
+  test('allows a valid commit after python -m pytest', () =>
+    assertAllows('python -m pytest && git commit -m "feat: add the thing"', 'valid message after a stray -m'));
+
+  test('allows a valid commit after a docker python -m run', () =>
+    assertAllows('docker compose run -T web python -m ruff check . && git commit -m "fix(x): tidy"', 'valid message after a stray -m'));
+
+  test('still blocks an invalid commit after python -m pytest', () =>
+    assertBlocks('python -m pytest && git commit -m "bad message not conventional"', 'invalid message after a stray -m'));
+});
+
+describe('commit-validate: still blocks invalid messages', () => {
+  const cases = [
+    ['plain invocation', 'git commit -m "bad message not conventional"'],
+    ['summary over the length cap', `git commit -m "feat: ${LONG_SUMMARY}"`],
+    // `git -C <path>` and `git -c <k>=<v>` put a non-flag token between `git` and
+    // `commit`; a guard that only allows a run of flags there stops matching, and
+    // then silently skips validation for these very common forms.
+    ['git -C <path> form', 'git -C /tmp/repo commit -m "bad message not conventional"'],
+    ['git -c <key>=<value> form', 'git -c user.email=a@b.c commit -m "bad message not conventional"'],
+    ['git --git-dir form', 'git --git-dir=/tmp/r/.git commit -m "bad message not conventional"'],
+    ['after a cd in the same command', 'cd /tmp/repo && git commit -m "bad message not conventional"'],
+    ['behind sudo', 'sudo git commit -m "bad message not conventional"'],
+    ['amend with a message', 'git commit --amend -m "bad message not conventional"'],
+    ['--message= form', 'git commit --message="bad message not conventional"'],
+    ['message supplied by heredoc', "git commit -F- <<'EOF'\nbad message not conventional\nEOF"],
+  ];
+
+  for (const [why, command] of cases) {
+    test(`blocks ${why}`, () => assertBlocks(command, why));
+  }
+});
+
+describe('commit-validate: lets valid commits through', () => {
+  const cases = [
+    ['conventional message with scope', 'git commit -m "feat(scope): add thing"'],
+    ['conventional message via git -C', 'git -C /tmp/repo commit -m "fix(api): handle null"'],
+    ['conventional message via heredoc', "git commit -F- <<'EOF'\nfeat(x): valid heredoc subject\nEOF"],
+    ['message read from a file', 'git commit -F /tmp/msg.txt'],
+    ['message written in the editor', 'git commit'],
+    ['valid commit followed by another command', 'git commit -m "chore: bump" && python -m pytest'],
+  ];
+
+  for (const [why, command] of cases) {
+    test(`allows ${why}`, () => assertAllows(command, why));
+  }
+});
+
+describe('commit-validate: degenerate input', () => {
+  test('allows an empty command', () => assertAllows('', 'empty command'));
+
+  test('does not crash on malformed stdin', () => {
+    const res = spawnSync(process.execPath, [SCRIPT], { input: 'not json at all', encoding: 'utf8' });
+    assert.strictEqual(res.status, 0, 'malformed payload should be ignored, not fatal');
+  });
+});

--- a/scripts/commit-validate.js
+++ b/scripts/commit-validate.js
@@ -3,15 +3,38 @@ const TYPES = ['feat', 'fix', 'refactor', 'test', 'docs', 'chore', 'perf', 'ci',
 const PATTERN = new RegExp(`^(${TYPES.join('|')})(\\([\\w\\-.,/ ]+\\))?!?: .+`);
 const MAX_SUMMARY = 72;
 
-// A real `git … commit` invocation. Anchored to the start of a shell command
-// segment (`^`, `;`, `&`, `|`, newline, `(`/`$(`, backtick) so a quoted mention
-// such as `echo 'git commit'` does not count, and bounded so that `git` and
-// `commit` belong to the same segment (`git log … | grep commit` does not match).
-// The gap before `git` rejects quote characters — that is what excludes quoted
-// mentions — while still allowing a prefix like `sudo ` or `FOO=1 `. The gap
-// between `git` and `commit` allows any flags, including ones that take a
-// separate value (`git -C /path commit`, `git -c user.email=a@b.c commit`).
-const GIT_COMMIT = /(?:^|[\n;&|(`])[^|&;\n'"]*?\bgit\b[^|&;\n]*?\bcommit\b/;
+// A real `git … commit` invocation, i.e. `git` as the command word of a shell
+// segment with `commit` as its subcommand.
+//
+//   (?:^|[\n;&|(`])          start of a command segment, so `echo git commit`
+//                            and `echo 'git commit'` are not invocations
+//   (?:\w+=\S*\s+|sudo…)*    the few prefixes that still leave git the command
+//   git\s+                   the command word itself
+//   (?:-\S+(?:\s+[^-\s]\S*)?\s+)*   only flags, each with an optional value, so
+//                            `git -C /path commit` and `git -c k=v commit` match
+//                            while `git log commit` does not
+const GIT_COMMIT = /(?:^|[\n;&|(`])\s*(?:\w+=\S*\s+|sudo\s+|command\s+)*git\s+(?:-\S+(?:\s+[^-\s]\S*)?\s+)*commit\b/;
+
+// The arguments belonging to that commit: everything after the `commit` verb up
+// to the first shell separator that is not inside quotes, so a later `&& python
+// -m pytest` is not mistaken for the message. A heredoc body may legally contain
+// separators, so once one is opened the arguments run to the end of the command.
+function commitArgs(rest) {
+  let single = false;
+  let double = false;
+  let heredoc = false;
+
+  for (let i = 0; i < rest.length; i++) {
+    const c = rest[i];
+    if (c === '\\' && !single) { i++; continue; }
+    if (c === "'" && !double) { single = !single; continue; }
+    if (c === '"' && !single) { double = !double; continue; }
+    if (single || double) continue;
+    if (c === '<' && rest[i + 1] === '<') { heredoc = true; i++; continue; }
+    if (!heredoc && (c === ';' || c === '&' || c === '|')) return rest.slice(0, i);
+  }
+  return rest;
+}
 
 function readStdin() {
   return new Promise(resolve => {
@@ -34,7 +57,7 @@ function extractMessage(command) {
   // "feat: x"` from being picked up instead of the real one.
   const gitCommit = command.match(GIT_COMMIT);
   if (!gitCommit) return { msg: null, form: 'not-a-commit' };
-  const args = command.slice(gitCommit.index + gitCommit[0].length);
+  const args = commitArgs(command.slice(gitCommit.index + gitCommit[0].length));
 
   const shortFlag = args.match(/(?:^|\s)-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
   if (shortFlag) {

--- a/scripts/commit-validate.js
+++ b/scripts/commit-validate.js
@@ -3,6 +3,16 @@ const TYPES = ['feat', 'fix', 'refactor', 'test', 'docs', 'chore', 'perf', 'ci',
 const PATTERN = new RegExp(`^(${TYPES.join('|')})(\\([\\w\\-.,/ ]+\\))?!?: .+`);
 const MAX_SUMMARY = 72;
 
+// A real `git … commit` invocation. Anchored to the start of a shell command
+// segment (`^`, `;`, `&`, `|`, newline, `(`/`$(`, backtick) so a quoted mention
+// such as `echo 'git commit'` does not count, and bounded so that `git` and
+// `commit` belong to the same segment (`git log … | grep commit` does not match).
+// The gap before `git` rejects quote characters — that is what excludes quoted
+// mentions — while still allowing a prefix like `sudo ` or `FOO=1 `. The gap
+// between `git` and `commit` allows any flags, including ones that take a
+// separate value (`git -C /path commit`, `git -c user.email=a@b.c commit`).
+const GIT_COMMIT = /(?:^|[\n;&|(`])[^|&;\n'"]*?\bgit\b[^|&;\n]*?\bcommit\b/;
+
 function readStdin() {
   return new Promise(resolve => {
     let data = '';
@@ -15,33 +25,41 @@ function readStdin() {
 function extractMessage(command) {
   if (!command) return { msg: null, form: 'empty' };
 
-  const shortFlag = command.match(/(?:^|\s)-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
+  // None of the sub-patterns below (-m, --message, heredoc, -F/--file) are
+  // specific to git — they match any command carrying those tokens. So first
+  // require a real `git … commit`, then scan only the text that FOLLOWS the
+  // `commit` verb. Both halves matter: the guard is what stops `python -m
+  // pytest` or `cat > f <<'EOF' … EOF` being read as a commit message, and the
+  // slice is what stops the stray `-m` in `python -m pytest && git commit -m
+  // "feat: x"` from being picked up instead of the real one.
+  const gitCommit = command.match(GIT_COMMIT);
+  if (!gitCommit) return { msg: null, form: 'not-a-commit' };
+  const args = command.slice(gitCommit.index + gitCommit[0].length);
+
+  const shortFlag = args.match(/(?:^|\s)-m\s+(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
   if (shortFlag) {
     const raw = shortFlag[1] || shortFlag[2] || shortFlag[3] || '';
     return { msg: raw.replace(/\\"/g, '"').replace(/\\'/g, "'"), form: '-m' };
   }
 
-  const longFlag = command.match(/--message(?:=|\s+)(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
+  const longFlag = args.match(/--message(?:=|\s+)(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|(\S+))/);
   if (longFlag) {
     const raw = longFlag[1] || longFlag[2] || longFlag[3] || '';
     return { msg: raw.replace(/\\"/g, '"').replace(/\\'/g, "'"), form: '--message' };
   }
 
-  const heredocAny = command.match(/<<-?\s*'?([A-Za-z_][A-Za-z0-9_]*)'?\s*\n([\s\S]*?)\n\s*\1\s*$/m);
+  const heredocAny = args.match(/<<-?\s*'?([A-Za-z_][A-Za-z0-9_]*)'?\s*\n([\s\S]*?)\n\s*\1\s*$/m);
   if (heredocAny) return { msg: heredocAny[2].split('\n')[0], form: 'heredoc' };
 
-  if (/(?:^|\s)-F(?:\s+\S+|=\S+)/.test(command) || /--file(?:=|\s+)\S+/.test(command)) {
+  if (/(?:^|\s)-F(?:\s+\S+|=\S+)/.test(args) || /--file(?:=|\s+)\S+/.test(args)) {
     return { msg: null, form: 'file' };
   }
 
-  if (/\bgit\s+(?:-[^\s]+\s+)*commit\b/.test(command)) {
-    const afterCommit = command.split(/\bcommit\b/)[1] || '';
-    const hasExplicitFlag = /(?:-m|--message|-F|--file|--amend)\b/.test(afterCommit);
-    if (!hasExplicitFlag) return { msg: null, form: 'editor' };
-    return { msg: null, form: 'unknown' };
-  }
-
-  return { msg: null, form: 'empty' };
+  // Reached only when the command IS a git commit (the guard above returned
+  // otherwise), so no second `git commit` test is needed here.
+  const hasExplicitFlag = /(?:-m|--message|-F|--file|--amend)\b/.test(args);
+  if (!hasExplicitFlag) return { msg: null, form: 'editor' };
+  return { msg: null, form: 'unknown' };
 }
 
 function validate(msg) {


### PR DESCRIPTION
Fixes #82.

> **Note on #83** — @slava07437352641-ops got to this first with the same core idea (guard `extractMessage`), and this PR builds on that. I opened a separate one because of two things the guard alone doesn't cover, both shown in the table below: #83's guard regex stops matching `git -C <path> commit`, which *silently disables* validation for that form, and a guard by itself still blocks `python -m pytest && git commit -m "feat: x"`. Happy to close this if you'd rather the fix land there — the diff applies either way.

## Bug

`extractMessage()` runs its `-m` / `--message` / heredoc / `-F` sub-patterns against the whole command line, with no check that the command is a `git commit` at all. None of those tokens are git-specific, so ordinary Bash work is read as a commit message and validated against the conventional-commit pattern — `exit 2`, call blocked:

```bash
python -m pytest tests/ -q                              # "pytest" parsed as the subject
docker compose run --rm -T web python -m ruff check .   # "ruff" parsed as the subject
cat > file.py <<'EOF'                                   # first heredoc line parsed as the subject
import json
EOF
python3 - <<'PY'
print("hello")
PY
```

Any heredoc in any command hits this, which is what makes it bite so often in practice.

## Fix

Two parts, and both are load-bearing:

1. **Recognise a real `git … commit`** before parsing anything; otherwise return `form: 'not-a-commit'`. `git` has to be the command word of a shell segment with `commit` as its subcommand — only variable assignments / `sudo` / `command` may precede it, and only flags, each with an optional value, may sit between the two. That accepts `git -C /path commit` and `git -c user.email=… commit` while rejecting `echo git commit …` and `git log commit …`.

2. **Parse the message only from that invocation's own arguments.** A guard alone is not enough: `python -m pytest && git commit -m "feat: x"` passes it, and the whole-line `-m` scan then finds `pytest` before the real message and blocks a good commit. `commitArgs()` takes the text after the `commit` verb and stops at the first shell separator outside quotes, so a chained `&& python -m pytest` can't supply the message either. A message may still contain `&` or `;`, and a heredoc body — which can legally contain separators — still runs to the end of the command.

The `git -C` handling is the part worth a close look. The existing `\bgit\s+(?:-[^\s]+\s+)*commit\b` pattern only permits a run of `-flag` tokens, so a flag taking a *separate* value breaks the run and the whole invocation stops being recognised. The failure is silent — nothing is blocked, the hook just quietly stops checking those commits, so nothing tells you it regressed.

This also makes the second `git commit` test at the end of `extractMessage()` unreachable, so it and its dead fallback are removed — that's the redundancy CodeRabbit flagged on #83.

## Evidence

33 commands run through the real hook contract (PreToolUse JSON on stdin → exit code), against `main`, against #83, and against this branch:

| Case | Expected | `main` | #83 | This PR |
|---|---|---|---|---|
| `python -m pytest tests/ -q` | allow | ❌ block | ✅ | ✅ |
| `docker … python -m ruff check .` | allow | ❌ block | ✅ | ✅ |
| `cat > f.py <<'EOF' … EOF` | allow | ❌ block | ✅ | ✅ |
| `python3 - <<'PY' … PY` | allow | ❌ block | ✅ | ✅ |
| `psql -U u -d d <<'SQL' … SQL` | allow | ❌ block | ✅ | ✅ |
| `ssh host <<'EOF' … EOF` | allow | ❌ block | ✅ | ✅ |
| `npm run build -- -m foo` | allow | ❌ block | ✅ | ✅ |
| `echo 'git commit' && python -m pytest` | allow | ❌ block | ❌ block | ✅ |
| `echo git commit -m "bad message"` | allow | ❌ block | ❌ block | ✅ |
| `git log commit -m "bad message"` | allow | ❌ block | ✅ | ✅ |
| `python -m pytest && git commit -m "feat: add the thing"` | allow | ❌ block | ❌ block | ✅ |
| `docker … python -m ruff … && git commit -m "fix(x): tidy"` | allow | ❌ block | ❌ block | ✅ |
| `git commit && python -m pytest` | allow | ❌ block | ❌ block | ✅ |
| `git commit && cat > f.py <<'EOF' … EOF` | allow | ❌ block | ❌ block | ✅ |
| `git -C /tmp/repo commit -m "bad message"` | **block** | ✅ | ❌ **allow** | ✅ |
| `git -c user.email=a@b.c commit -m "bad message"` | **block** | ✅ | ❌ **allow** | ✅ |
| `git commit -m "bad message"` | block | ✅ | ✅ | ✅ |
| `git commit -m "feat: <80 chars>"` | block | ✅ | ✅ | ✅ |
| `cd /repo && git commit -m "bad message"` | block | ✅ | ✅ | ✅ |
| `sudo git commit -m "bad message"` | block | ✅ | ✅ | ✅ |
| `git --git-dir=… commit -m "bad message"` | block | ✅ | ✅ | ✅ |
| `git commit --amend -m "bad message"` | block | ✅ | ✅ | ✅ |
| `git commit --message="bad message"` | block | ✅ | ✅ | ✅ |
| `git commit -F- <<'EOF' bad message EOF` | block | ✅ | ✅ | ✅ |
| `git commit -F- <<'EOF' bad; message & EOF` | block | ✅ | ✅ | ✅ |
| `git commit -m "feat(scope): add thing"` | allow | ✅ | ✅ | ✅ |
| `git -C /repo commit -m "fix(api): handle null"` | allow | ✅ | ✅ | ✅ |
| `git commit -m "fix(api): guard a & b; retry"` | allow | ✅ | ✅ | ✅ |
| `git commit -F /tmp/msg.txt` | allow | ✅ | ✅ | ✅ |
| `git commit` | allow | ✅ | ✅ | ✅ |
| `git commit -m "chore: bump" && python -m pytest` | allow | ✅ | ✅ | ✅ |
| `git commit -F- <<'EOF' feat(x): … EOF` | allow | ✅ | ✅ | ✅ |
| `git log --oneline -5 \| grep commit` | allow | ✅ | ✅ | ✅ |

**Totals: `main` 19/33 · #83 25/33 · this PR 33/33.**

## Tests

New `scripts/__tests__/commit-validate.test.js` — 36 cases over four groups (not-a-commit, real commit behind a stray `-m`, still-blocks, still-allows), driving the script as a subprocess so the stdin/exit-code wiring is covered too, not just the regexes.

The "still blocks" group is the important half. A false-positive fix can always be faked by turning validation off, so those cases are what keep a future guard honest — run against #83 they go red on exactly the two `git -C` / `git -c` rows above.

Verified by reverting the script under the same tests:

| Script under test | Result |
|---|---|
| this branch | 36/36 pass |
| `main` | 22/36 — the false positives |
| #83 | 28/36 — its 2 silent regressions + the remaining false positives |

Wired up as `npm run test:hooks`, with `npm test` now running `test:optimizer && test:hooks`. It needs no devDependencies (plain `node --test`, Node 18+), so it runs on a bare checkout.

One thing I left alone: `.github/workflows/ci.yml` doesn't run `npm test` today, so these won't execute in CI as-is. Adding that step felt like scope creep for a bug fix — say the word and I'll push it here, or leave it for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C9GqsebkwiUP5eCCYoz7HC
