### PR TITLE
feat(llm-council): add --max-tokens CLI flag

### DIFF
--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -168,7 +168,15 @@ async function cmdRun(args) {
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
-  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
+  function parseIntSafe(val, name) {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n <= 0 || n !== Math.floor(n)) {
+      console.error(`Invalid --${name}: ${val} (must be a positive integer)`);
+      process.exit(2);
+    }
+    return n;
+  }
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseIntSafe(args['max-tokens'], 'max-tokens');
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -57,6 +57,10 @@ function pickProvider(arg) {
   return null;
 }
 
+// Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
+// Defaults preserve previous hard-coded behavior.
+const RUN_OPTS = { max_tokens: 4000 };
+
 function postJSON(urlStr, body, headers, timeoutMs = 120000) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
@@ -84,7 +88,7 @@ async function callOpenAICompat(provider, model, system, user) {
   const res = await postJSON(url, {
     model,
     messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
   }, { Authorization: `Bearer ${process.env[provider.envKey]}` });
   const elapsed = Date.now() - start;
@@ -100,7 +104,7 @@ async function callAnthropic(provider, model, system, user) {
   const url = `${provider.baseUrl}/v1/messages`;
   const res = await postJSON(url, {
     model,
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     system,
     messages: [{ role: 'user', content: user }],
   }, {
@@ -163,6 +167,8 @@ async function cmdRun(args) {
   if (!providerName) { console.error('No provider env var set. Try ANTHROPIC_API_KEY or OPENAI_API_KEY.'); process.exit(2); }
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
+
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -266,9 +272,12 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
   council.js providers
-  council.js show <session-id>`);
+  council.js show <session-id>
+
+Options:
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Fixes #88.

## What

`skills/llm-council/scripts/council.js` hardcoded `max_tokens: 4000` in both `callOpenAICompat` (line 87) and `callAnthropic` (line 103). This is too small for modern reasoning models (Nemotron-3-Ultra, GLM-5.2, DeepSeek-V4, Claude with thinking enabled), which routinely need 8K–32K output tokens for their reasoning chain. With the current default they either:

- return an empty `choices[0].message.content` (the model exhausted its budget before emitting any final answer), or
- silently truncate the chain, producing a degraded synthesis.

There's no way to override this from the CLI — users have to monkey-patch the constant.

## Change

- Introduce a tiny `RUN_OPTS` struct (`const RUN_OPTS = { max_tokens: 4000 };`) at the top of the file.
- Both call functions read `RUN_OPTS.max_tokens` instead of the literal.
- Add `--max-tokens N` parsing in `cmdRun` (default preserves current behavior).
- Document the flag in `usage()`.

## Reproduction (before this PR)

```bash
node council.js run "Top 3 criteria Georgian diaspora in EU uses to pick a bank." \
  --provider openrouter --models "nvidia/nemotron-3-ultra-550b-a55b:free" --chairman "..." \
  --timeout 300000
# phase1_responses.json: { "success": true, "content": "", "latency_ms": 18916 }
```

## After this PR

```bash
node council.js run "<query>" --models "..." --chairman "..." --max-tokens 16000
```

## Scope

This PR is intentionally minimal — only adds the knob, doesn't touch retry/timeout/sequential logic (separate concerns for separate PRs). Diff: 13 +, 4 -.

## Backward compatibility

Default `4000` preserved verbatim. Existing users see no behavior change unless they pass `--max-tokens`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `--max-tokens` option to customize the maximum response length when running the council script.
  - The default remains 4,000 tokens.
  - The setting is applied consistently across supported AI providers.

- **Documentation**
  - Updated command-line usage information with the new option, default value, and guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->