### PR TITLE
feat(llm-council): add --timeout CLI flag

### DIFF
--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -168,8 +168,16 @@ async function cmdRun(args) {
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
-  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
-  if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
+  function parseIntSafe(val, name) {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n <= 0 || n !== Math.floor(n)) {
+      console.error(`Invalid --${name}: ${val} (must be a positive integer)`);
+      process.exit(2);
+    }
+    return n;
+  }
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseIntSafe(args['max-tokens'], 'max-tokens');
+  if (args.timeout) RUN_OPTS.timeout_ms = parseIntSafe(args.timeout, 'timeout');
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,9 +59,9 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000 };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000 };
 
-function postJSON(urlStr, body, headers, timeoutMs = 120000) {
+function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
     const data = JSON.stringify(body);
@@ -169,6 +169,7 @@ async function cmdRun(args) {
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
   if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
+  if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -272,12 +273,14 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+                        [--max-tokens N] [--timeout ms]
   council.js providers
   council.js show <session-id>
 
 Options:
-  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
+  --timeout     HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -57,6 +57,10 @@ function pickProvider(arg) {
   return null;
 }
 
+// Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
+// Defaults preserve previous hard-coded behavior.
+const RUN_OPTS = { max_tokens: 4000 };
+
 function postJSON(urlStr, body, headers, timeoutMs = 120000) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
@@ -84,7 +88,7 @@ async function callOpenAICompat(provider, model, system, user) {
   const res = await postJSON(url, {
     model,
     messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
   }, { Authorization: `Bearer ${process.env[provider.envKey]}` });
   const elapsed = Date.now() - start;
@@ -100,7 +104,7 @@ async function callAnthropic(provider, model, system, user) {
   const url = `${provider.baseUrl}/v1/messages`;
   const res = await postJSON(url, {
     model,
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     system,
     messages: [{ role: 'user', content: user }],
   }, {
@@ -163,6 +167,8 @@ async function cmdRun(args) {
   if (!providerName) { console.error('No provider env var set. Try ANTHROPIC_API_KEY or OPENAI_API_KEY.'); process.exit(2); }
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
+
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -266,9 +272,12 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
   council.js providers
-  council.js show <session-id>`);
+  council.js show <session-id>
+
+Options:
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Depends on #89.
Fixes #90.

## What

The HTTP request timeout is hardcoded at 120s in `postJSON()`. This is too short for slow upstream endpoints:

- NVIDIA NIM reasoning models (GLM-5.2, Nemotron-3-Ultra) routinely exceed 120s on cold-start
- OpenRouter under high upstream queueing pressure
- Phase 3 chairman calls with very large ranking contexts

Failing with `ETIMEDOUT` or `council request timeout` and no way to extend.

## Change

- Add `timeout_ms: 120000` to `RUN_OPTS` struct (introduced by #89)
- `postJSON` reads `RUN_OPTS.timeout_ms` as default
- Parse `--timeout N` CLI flag in `cmdRun`
- Document in `usage()`

## After this PR

```bash
node council.js run "<query>" --models "..." --chairman "..." --timeout 300000
```

## Scope

Intentionally minimal — only adds the knob. Diff: 7 +, 4 -. Default `120000` preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line options to configure maximum response tokens and request timeouts.
  * Settings apply to supported AI service requests and override default values.

* **Documentation**
  * Updated command-line usage information to include the new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->