### PR TITLE
feat(llm-council): add --max-retries with bounded retry + exponential backoff

### DIFF
--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -43,9 +43,18 @@ Default model rosters per provider live in `scripts/council.js` and can be overr
 
 ```
 node $SKILL_ROOT/scripts/council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider <name>] [--wiki <slug>]
+                        [--max-tokens N] [--timeout ms] [--max-retries N]
 node $SKILL_ROOT/scripts/council.js providers
 node $SKILL_ROOT/scripts/council.js show <session-id>
 ```
+
+### Runtime options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-tokens` | 4000 | Max output tokens per model call. Bump to 16000+ for reasoning models. |
+| `--timeout` | 120000 | HTTP request timeout in ms. Bump to 300000+ for slow endpoints (NVIDIA NIM). |
+| `--max-retries` | 1 | Retry count on 429/5xx and connection errors. Exponential backoff (2s, 4s, 8s...). |
 
 `--wiki <slug>` writes the full transcript to `<wiki>/derived/council/<session-id>.md` and registers it via `wiki-cli.js page` so it shows in FTS5 search.
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,7 +59,7 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000 };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000, max_retries: 1 };
 
 function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
@@ -85,12 +85,33 @@ function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
 async function callOpenAICompat(provider, model, system, user) {
   const start = Date.now();
   const url = `${provider.baseUrl}/chat/completions`;
-  const res = await postJSON(url, {
+  const payload = {
     model,
     messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
     max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
-  }, { Authorization: `Bearer ${process.env[provider.envKey]}` });
+  };
+  const authHeaders = { Authorization: `Bearer ${process.env[provider.envKey]}` };
+
+  let res;
+  let attempt = 0;
+  while (true) {
+    try {
+      res = await postJSON(url, payload, authHeaders);
+    } catch (e) {
+      // Connection-level error (ETIMEDOUT, ECONNRESET)
+      if (attempt >= RUN_OPTS.max_retries) {
+        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
+      }
+      attempt += 1;
+      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+      continue;
+    }
+    if (res.status < 500 && res.status !== 429) break;
+    if (attempt >= RUN_OPTS.max_retries) break;
+    attempt += 1;
+    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+  }
   const elapsed = Date.now() - start;
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
@@ -102,15 +123,35 @@ async function callOpenAICompat(provider, model, system, user) {
 async function callAnthropic(provider, model, system, user) {
   const start = Date.now();
   const url = `${provider.baseUrl}/v1/messages`;
-  const res = await postJSON(url, {
+  const payload = {
     model,
     max_tokens: RUN_OPTS.max_tokens,
     system,
     messages: [{ role: 'user', content: user }],
-  }, {
+  };
+  const authHeaders = {
     'x-api-key': process.env[provider.envKey],
     'anthropic-version': '2023-06-01',
-  });
+  };
+
+  let res;
+  let attempt = 0;
+  while (true) {
+    try {
+      res = await postJSON(url, payload, authHeaders);
+    } catch (e) {
+      if (attempt >= RUN_OPTS.max_retries) {
+        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
+      }
+      attempt += 1;
+      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+      continue;
+    }
+    if (res.status < 500 && res.status !== 429) break;
+    if (attempt >= RUN_OPTS.max_retries) break;
+    attempt += 1;
+    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+  }
   const elapsed = Date.now() - start;
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
@@ -170,6 +211,7 @@ async function cmdRun(args) {
 
   if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
   if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
+  if (args['max-retries']) RUN_OPTS.max_retries = parseInt(args['max-retries'], 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -274,13 +316,14 @@ function cmdShow(args) {
 function usage() {
   console.error(`Usage:
   council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
-                        [--max-tokens N] [--timeout ms]
+                        [--max-tokens N] [--timeout ms] [--max-retries N]
   council.js providers
   council.js show <session-id>
 
 Options:
-  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
-  --timeout     HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)`);
+  --max-tokens   Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
+  --timeout      HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)
+  --max-retries  Retry count on 429/5xx (default 1; exponential backoff 2s, 4s, ...)`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,9 +59,9 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000 };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000 };
 
-function postJSON(urlStr, body, headers, timeoutMs = 120000) {
+function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
     const data = JSON.stringify(body);
@@ -169,6 +169,7 @@ async function cmdRun(args) {
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
   if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
+  if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -272,12 +273,14 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+                        [--max-tokens N] [--timeout ms]
   council.js providers
   council.js show <session-id>
 
 Options:
-  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
+  --timeout     HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -82,6 +82,26 @@ function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   });
 }
 
+async function postJSONWithRetry(urlStr, body, headers) {
+  const delay = attempt => new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+  let res;
+  let lastError;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      res = await postJSON(urlStr, body, headers);
+    } catch (e) {
+      // Connection-level error (ETIMEDOUT, ECONNRESET)
+      lastError = e;
+      if (attempt >= RUN_OPTS.max_retries) return { error: lastError };
+      await delay(attempt + 1);
+      continue;
+    }
+    if (res.status < 500 && res.status !== 429) return { res };
+    if (attempt >= RUN_OPTS.max_retries) return { res };
+    await delay(attempt + 1);
+  }
+}
+
 async function callOpenAICompat(provider, model, system, user) {
   const start = Date.now();
   const url = `${provider.baseUrl}/chat/completions`;
@@ -93,26 +113,9 @@ async function callOpenAICompat(provider, model, system, user) {
   };
   const authHeaders = { Authorization: `Bearer ${process.env[provider.envKey]}` };
 
-  let res;
-  let attempt = 0;
-  while (true) {
-    try {
-      res = await postJSON(url, payload, authHeaders);
-    } catch (e) {
-      // Connection-level error (ETIMEDOUT, ECONNRESET)
-      if (attempt >= RUN_OPTS.max_retries) {
-        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
-      }
-      attempt += 1;
-      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-      continue;
-    }
-    if (res.status < 500 && res.status !== 429) break;
-    if (attempt >= RUN_OPTS.max_retries) break;
-    attempt += 1;
-    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-  }
+  const { res, error } = await postJSONWithRetry(url, payload, authHeaders);
   const elapsed = Date.now() - start;
+  if (error) return { success: false, content: `[ERROR connection: ${error.code || error.message}]`, model, latency_ms: elapsed };
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
   try { data = JSON.parse(res.body); } catch (e) { return { success: false, content: `[parse-error]`, model, latency_ms: elapsed }; }
@@ -134,25 +137,9 @@ async function callAnthropic(provider, model, system, user) {
     'anthropic-version': '2023-06-01',
   };
 
-  let res;
-  let attempt = 0;
-  while (true) {
-    try {
-      res = await postJSON(url, payload, authHeaders);
-    } catch (e) {
-      if (attempt >= RUN_OPTS.max_retries) {
-        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
-      }
-      attempt += 1;
-      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-      continue;
-    }
-    if (res.status < 500 && res.status !== 429) break;
-    if (attempt >= RUN_OPTS.max_retries) break;
-    attempt += 1;
-    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-  }
+  const { res, error } = await postJSONWithRetry(url, payload, authHeaders);
   const elapsed = Date.now() - start;
+  if (error) return { success: false, content: `[ERROR connection: ${error.code || error.message}]`, model, latency_ms: elapsed };
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
   try { data = JSON.parse(res.body); } catch { return { success: false, content: '[parse-error]', model, latency_ms: elapsed }; }

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -209,9 +209,17 @@ async function cmdRun(args) {
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
-  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
-  if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
-  if (args['max-retries']) RUN_OPTS.max_retries = parseInt(args['max-retries'], 10);
+  function parseIntSafe(val, name) {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n <= 0 || n !== Math.floor(n)) {
+      console.error(`Invalid --${name}: ${val} (must be a positive integer)`);
+      process.exit(2);
+    }
+    return n;
+  }
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseIntSafe(args['max-tokens'], 'max-tokens');
+  if (args.timeout) RUN_OPTS.timeout_ms = parseIntSafe(args.timeout, 'timeout');
+  if (args['max-retries']) RUN_OPTS.max_retries = parseIntSafe(args['max-retries'], 'max-retries');
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -57,6 +57,10 @@ function pickProvider(arg) {
   return null;
 }
 
+// Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
+// Defaults preserve previous hard-coded behavior.
+const RUN_OPTS = { max_tokens: 4000 };
+
 function postJSON(urlStr, body, headers, timeoutMs = 120000) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
@@ -84,7 +88,7 @@ async function callOpenAICompat(provider, model, system, user) {
   const res = await postJSON(url, {
     model,
     messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
   }, { Authorization: `Bearer ${process.env[provider.envKey]}` });
   const elapsed = Date.now() - start;
@@ -100,7 +104,7 @@ async function callAnthropic(provider, model, system, user) {
   const url = `${provider.baseUrl}/v1/messages`;
   const res = await postJSON(url, {
     model,
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     system,
     messages: [{ role: 'user', content: user }],
   }, {
@@ -163,6 +167,8 @@ async function cmdRun(args) {
   if (!providerName) { console.error('No provider env var set. Try ANTHROPIC_API_KEY or OPENAI_API_KEY.'); process.exit(2); }
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
+
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -266,9 +272,12 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
   council.js providers
-  council.js show <session-id>`);
+  council.js show <session-id>
+
+Options:
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Depends on #91.
Fixes #92.

## What

`callOpenAICompat` and `callAnthropic` make a single HTTP request per model call. A transient 429 or 5xx kills the session with no recovery. Free-tier endpoints (NVIDIA NIM, OpenRouter `:free`) are especially prone.

## Change

- Add `max_retries: 1` to `RUN_OPTS`
- Both call functions now implement a bounded retry loop:
  - Connection-level errors (ETIMEDOUT, ECONNRESET) caught and retried
  - 429/5xx retried with exponential backoff (2s, 4s, 8s...)
  - After retries exhausted, fail fast with `[ERROR ...]` message
- Parse `--max-retries N` CLI flag in `cmdRun`
- Document in `usage()`

## After this PR

```bash
node council.js run "<query>" --models "..." --chairman "..." --max-retries 3
```

## Backward compatibility

Default `max_retries: 1` (one attempt + one retry) preserves the current one-shot semantics with a single retry on transient failures. Diff: 52 +, 9 -.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added command-line options to configure model response token limits, request timeouts, and retry behavior.
  - Added usage documentation describing the new runtime settings and their defaults.

- **Bug Fixes**
  - Improved resilience to temporary connection failures, rate limits, and server errors with automatic retries.
  - Added clear, structured errors when requests remain unsuccessful after all retry attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->