### PR TITLE
feat(llm-council): add --reasoning-effort CLI flag

### DIFF
--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -43,9 +43,18 @@ Default model rosters per provider live in `scripts/council.js` and can be overr
 
 ```
 node $SKILL_ROOT/scripts/council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider <name>] [--wiki <slug>]
+                        [--max-tokens N] [--timeout ms] [--max-retries N]
 node $SKILL_ROOT/scripts/council.js providers
 node $SKILL_ROOT/scripts/council.js show <session-id>
 ```
+
+### Runtime options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--max-tokens` | 4000 | Max output tokens per model call. Bump to 16000+ for reasoning models. |
+| `--timeout` | 120000 | HTTP request timeout in ms. Bump to 300000+ for slow endpoints (NVIDIA NIM). |
+| `--max-retries` | 1 | Retry count on 429/5xx and connection errors. Exponential backoff (2s, 4s, 8s...). |
 
 `--wiki <slug>` writes the full transcript to `<wiki>/derived/council/<session-id>.md` and registers it via `wiki-cli.js page` so it shows in FTS5 search.
 

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -42,8 +42,8 @@ Default model rosters per provider live in `scripts/council.js` and can be overr
 ## Commands
 
 ```
-node $SKILL_ROOT/scripts/council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider <name>] [--wiki <slug>]
-                        [--max-tokens N] [--timeout ms] [--max-retries N]
+node $SKILL_ROOT/scripts/council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider <name>] [--wiki <slug>]\
+                        [--max-tokens N] [--timeout ms] [--max-retries N] [--sequential]
 node $SKILL_ROOT/scripts/council.js providers
 node $SKILL_ROOT/scripts/council.js show <session-id>
 ```
@@ -55,6 +55,7 @@ node $SKILL_ROOT/scripts/council.js show <session-id>
 | `--max-tokens` | 4000 | Max output tokens per model call. Bump to 16000+ for reasoning models. |
 | `--timeout` | 120000 | HTTP request timeout in ms. Bump to 300000+ for slow endpoints (NVIDIA NIM). |
 | `--max-retries` | 1 | Retry count on 429/5xx and connection errors. Exponential backoff (2s, 4s, 8s...). |
+| `--sequential` | false | Run model calls one at a time instead of in parallel. Use when free endpoints reject concurrent requests. |
 
 `--wiki <slug>` writes the full transcript to `<wiki>/derived/council/<session-id>.md` and registers it via `wiki-cli.js page` so it shows in FTS5 search.
 

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -19,9 +19,11 @@ Karpathy's LLM Council pattern, provider-agnostic. dair-academy's version hardco
 
 ## Three phases
 
-1. **Independent**: each model answers in parallel
-2. **Ranking**: each model ranks anonymized peer responses
+1. **Independent**: each model answers in parallel by default
+2. **Ranking**: each model ranks anonymized peer responses in parallel by default
 3. **Synthesis**: chairman model reads all responses + rankings → final answer
+
+`--sequential` overrides the default parallel behavior for phases 1 and 2, running their model calls one at a time.
 
 ## Provider config
 

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -45,7 +45,7 @@ Default model rosters per provider live in `scripts/council.js` and can be overr
 
 ```
 node $SKILL_ROOT/scripts/council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider <name>] [--wiki <slug>]\
-                        [--max-tokens N] [--timeout ms] [--max-retries N] [--sequential]
+                        [--max-tokens N] [--timeout ms] [--max-retries N] [--sequential] [--reasoning-effort low|medium|high]
 node $SKILL_ROOT/scripts/council.js providers
 node $SKILL_ROOT/scripts/council.js show <session-id>
 ```
@@ -58,6 +58,7 @@ node $SKILL_ROOT/scripts/council.js show <session-id>
 | `--timeout` | 120000 | HTTP request timeout in ms. Bump to 300000+ for slow endpoints (NVIDIA NIM). |
 | `--max-retries` | 1 | Retry count on 429/5xx and connection errors. Exponential backoff (2s, 4s, 8s...). |
 | `--sequential` | false | Run model calls one at a time instead of in parallel. Use when free endpoints reject concurrent requests. |
+| `--reasoning-effort` | — | low\|medium\|high passed as `reasoning.effort` (OpenAI-compat) or `output_config.effort` (Anthropic adaptive thinking). |
 
 `--wiki <slug>` writes the full transcript to `<wiki>/derived/council/<session-id>.md` and registers it via `wiki-cli.js page` so it shows in FTS5 search.
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -133,7 +133,10 @@ async function callAnthropic(provider, model, system, user) {
     system,
     messages: [{ role: 'user', content: user }],
   };
-  if (RUN_OPTS.reasoning_effort) payload.thinking = { type: 'adaptive' };
+  if (RUN_OPTS.reasoning_effort) {
+    payload.thinking = { type: 'adaptive' };
+    payload.output_config = { effort: RUN_OPTS.reasoning_effort };
+  }
   const authHeaders = {
     'x-api-key': process.env[provider.envKey],
     'anthropic-version': '2023-06-01',

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -212,7 +212,7 @@ function parseIntSafe(val, name) {
   // Run a list of async callables either in parallel (default) or sequentially.
   // Sequential mode avoids concurrent-request limits on free NIM/OpenRouter endpoints.
   async function runCalls(callables) {
-    if (!RUN_OPTS.sequential) return Promise.allSettled(callables);
+    if (!RUN_OPTS.sequential) return Promise.allSettled(callables.map(fn => fn()));
     const results = [];
     for (const fn of callables) {
       try { results.push({ status: 'fulfilled', value: await fn() }); }

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,7 +59,7 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000, max_retries: 1 };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000, max_retries: 1, sequential: false };
 
 function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
@@ -196,7 +196,7 @@ async function cmdRun(args) {
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
-  function parseIntSafe(val, name) {
+function parseIntSafe(val, name) {
     const n = parseInt(val, 10);
     if (isNaN(n) || n <= 0 || n !== Math.floor(n)) {
       console.error(`Invalid --${name}: ${val} (must be a positive integer)`);
@@ -207,6 +207,19 @@ async function cmdRun(args) {
   if (args['max-tokens']) RUN_OPTS.max_tokens = parseIntSafe(args['max-tokens'], 'max-tokens');
   if (args.timeout) RUN_OPTS.timeout_ms = parseIntSafe(args.timeout, 'timeout');
   if (args['max-retries']) RUN_OPTS.max_retries = parseIntSafe(args['max-retries'], 'max-retries');
+  if (args.sequential) RUN_OPTS.sequential = true;
+
+  // Run a list of async callables either in parallel (default) or sequentially.
+  // Sequential mode avoids concurrent-request limits on free NIM/OpenRouter endpoints.
+  async function runCalls(callables) {
+    if (!RUN_OPTS.sequential) return Promise.allSettled(callables);
+    const results = [];
+    for (const fn of callables) {
+      try { results.push({ status: 'fulfilled', value: await fn() }); }
+      catch (e) { results.push({ status: 'rejected', reason: e }); }
+    }
+    return results;
+  }
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -226,7 +239,7 @@ async function cmdRun(args) {
 
   // Phase 1
   const sysIndep = 'You are participating in an LLM council deliberation. Provide your best, most thoughtful response to the query. Be comprehensive but focused.';
-  const phase1Settled = await Promise.allSettled(models.map(m => provider.call(provider, m, sysIndep, query)));
+  const phase1Settled = await runCalls(models.map(m => () => provider.call(provider, m, sysIndep, query)));
   const phase1Entries = phase1Settled.map((s, i) => settledToEntry(models[i], s));
   const phase1 = Object.fromEntries(models.map((m, i) => [m, phase1Entries[i]]));
   fs.writeFileSync(path.join(sessionDir, 'phase1_responses.json'), JSON.stringify(phase1, null, 2));
@@ -237,7 +250,7 @@ async function cmdRun(args) {
   const anon = models.map(m => `=== Response ${labelOf[m]} ===\n${phase1[m].content}`).join('\n\n');
   const sysRank = (own) => `You are ranking AI responses objectively. Your own response is labeled '${own}'.`;
   const userRank = `QUERY:\n${query}\n\nRESPONSES:\n${anon}\n\nRank from BEST to WORST. Format:\nRANKINGS:\n1. [Letter] - [reason]\n2. [Letter] - [reason]\n...`;
-  const phase2Settled = await Promise.allSettled(models.map(m => provider.call(provider, m, sysRank(labelOf[m]), userRank)));
+  const phase2Settled = await runCalls(models.map(m => () => provider.call(provider, m, sysRank(labelOf[m]), userRank)));
   const phase2Entries = phase2Settled.map((s, i) => settledToEntry(models[i], s));
   const phase2 = { label_of: labelOf, rankings: Object.fromEntries(models.map((m, i) => [m, phase2Entries[i]])) };
   fs.writeFileSync(path.join(sessionDir, 'phase2_rankings.json'), JSON.stringify(phase2, null, 2));
@@ -311,14 +324,16 @@ function cmdShow(args) {
 function usage() {
   console.error(`Usage:
   council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
-                        [--max-tokens N] [--timeout ms] [--max-retries N]
+                        [--max-tokens N] [--timeout ms] [--max-retries N] [--sequential]
   council.js providers
   council.js show <session-id>
 
 Options:
   --max-tokens   Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
   --timeout      HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)
-  --max-retries  Retry count on 429/5xx (default 1; exponential backoff 2s, 4s, ...)`);
+  --max-retries  Retry count on 429/5xx (default 1; exponential backoff 2s, 4s, ...)
+  --sequential   Run model calls one at a time instead of in parallel (use when free endpoints
+                 like NVIDIA NIM reject concurrent requests with ETIMEDOUT / 429)`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,7 +59,7 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000 };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000, max_retries: 1 };
 
 function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
@@ -85,12 +85,33 @@ function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
 async function callOpenAICompat(provider, model, system, user) {
   const start = Date.now();
   const url = `${provider.baseUrl}/chat/completions`;
-  const res = await postJSON(url, {
+  const payload = {
     model,
     messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
     max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
-  }, { Authorization: `Bearer ${process.env[provider.envKey]}` });
+  };
+  const authHeaders = { Authorization: `Bearer ${process.env[provider.envKey]}` };
+
+  let res;
+  let attempt = 0;
+  while (true) {
+    try {
+      res = await postJSON(url, payload, authHeaders);
+    } catch (e) {
+      // Connection-level error (ETIMEDOUT, ECONNRESET)
+      if (attempt >= RUN_OPTS.max_retries) {
+        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
+      }
+      attempt += 1;
+      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+      continue;
+    }
+    if (res.status < 500 && res.status !== 429) break;
+    if (attempt >= RUN_OPTS.max_retries) break;
+    attempt += 1;
+    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+  }
   const elapsed = Date.now() - start;
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
@@ -102,15 +123,35 @@ async function callOpenAICompat(provider, model, system, user) {
 async function callAnthropic(provider, model, system, user) {
   const start = Date.now();
   const url = `${provider.baseUrl}/v1/messages`;
-  const res = await postJSON(url, {
+  const payload = {
     model,
     max_tokens: RUN_OPTS.max_tokens,
     system,
     messages: [{ role: 'user', content: user }],
-  }, {
+  };
+  const authHeaders = {
     'x-api-key': process.env[provider.envKey],
     'anthropic-version': '2023-06-01',
-  });
+  };
+
+  let res;
+  let attempt = 0;
+  while (true) {
+    try {
+      res = await postJSON(url, payload, authHeaders);
+    } catch (e) {
+      if (attempt >= RUN_OPTS.max_retries) {
+        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
+      }
+      attempt += 1;
+      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+      continue;
+    }
+    if (res.status < 500 && res.status !== 429) break;
+    if (attempt >= RUN_OPTS.max_retries) break;
+    attempt += 1;
+    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+  }
   const elapsed = Date.now() - start;
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
@@ -170,6 +211,7 @@ async function cmdRun(args) {
 
   if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
   if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
+  if (args['max-retries']) RUN_OPTS.max_retries = parseInt(args['max-retries'], 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -274,13 +316,14 @@ function cmdShow(args) {
 function usage() {
   console.error(`Usage:
   council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
-                        [--max-tokens N] [--timeout ms]
+                        [--max-tokens N] [--timeout ms] [--max-retries N]
   council.js providers
   council.js show <session-id>
 
 Options:
-  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
-  --timeout     HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)`);
+  --max-tokens   Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
+  --timeout      HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)
+  --max-retries  Retry count on 429/5xx (default 1; exponential backoff 2s, 4s, ...)`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,9 +59,9 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000 };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000 };
 
-function postJSON(urlStr, body, headers, timeoutMs = 120000) {
+function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
     const data = JSON.stringify(body);
@@ -169,6 +169,7 @@ async function cmdRun(args) {
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
   if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
+  if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -272,12 +273,14 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+                        [--max-tokens N] [--timeout ms]
   council.js providers
   council.js show <session-id>
 
 Options:
-  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
+  --timeout     HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -59,7 +59,7 @@ function pickProvider(arg) {
 
 // Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
 // Defaults preserve previous hard-coded behavior.
-const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000, max_retries: 1, sequential: false };
+const RUN_OPTS = { max_tokens: 4000, timeout_ms: 120000, max_retries: 1, sequential: false, reasoning_effort: null };
 
 function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   return new Promise((resolve, reject) => {
@@ -111,6 +111,7 @@ async function callOpenAICompat(provider, model, system, user) {
     max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
   };
+  if (RUN_OPTS.reasoning_effort) payload.reasoning = { effort: RUN_OPTS.reasoning_effort };
   const authHeaders = { Authorization: `Bearer ${process.env[provider.envKey]}` };
 
   const { res, error } = await postJSONWithRetry(url, payload, authHeaders);
@@ -132,6 +133,7 @@ async function callAnthropic(provider, model, system, user) {
     system,
     messages: [{ role: 'user', content: user }],
   };
+  if (RUN_OPTS.reasoning_effort) payload.thinking = { type: 'enabled', budget_tokens: Math.min(RUN_OPTS.max_tokens * 0.8, 16000) };
   const authHeaders = {
     'x-api-key': process.env[provider.envKey],
     'anthropic-version': '2023-06-01',
@@ -208,6 +210,7 @@ function parseIntSafe(val, name) {
   if (args.timeout) RUN_OPTS.timeout_ms = parseIntSafe(args.timeout, 'timeout');
   if (args['max-retries']) RUN_OPTS.max_retries = parseIntSafe(args['max-retries'], 'max-retries');
   if (args.sequential) RUN_OPTS.sequential = true;
+  if (args['reasoning-effort']) RUN_OPTS.reasoning_effort = args['reasoning-effort'];
 
   // Run a list of async callables either in parallel (default) or sequentially.
   // Sequential mode avoids concurrent-request limits on free NIM/OpenRouter endpoints.
@@ -325,15 +328,18 @@ function usage() {
   console.error(`Usage:
   council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
                         [--max-tokens N] [--timeout ms] [--max-retries N] [--sequential]
+                        [--reasoning-effort low|medium|high]
   council.js providers
   council.js show <session-id>
 
 Options:
-  --max-tokens   Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
-  --timeout      HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)
-  --max-retries  Retry count on connection errors and 429/5xx (default 1; exponential backoff 2s, 4s, ...)
-  --sequential   Run model calls one at a time instead of in parallel (use when free endpoints
-                 like NVIDIA NIM reject concurrent requests with ETIMEDOUT / 429)`);
+  --max-tokens       Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
+  --timeout          HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)
+  --max-retries      Retry count on connection errors and 429/5xx (default 1; exponential backoff 2s, 4s, ...)
+  --sequential       Run model calls one at a time instead of in parallel (use when free endpoints
+                     like NVIDIA NIM reject concurrent requests with ETIMEDOUT / 429)
+  --reasoning-effort Pass reasoning effort to OpenAI-compat payload as reasoning.effort
+                     (low|medium|high) — for o1/o3/DeepSeek/Claude thinking models`);
   process.exit(1);
 }
 

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -82,6 +82,26 @@ function postJSON(urlStr, body, headers, timeoutMs = RUN_OPTS.timeout_ms) {
   });
 }
 
+async function postJSONWithRetry(urlStr, body, headers) {
+  const delay = attempt => new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+  let res;
+  let lastError;
+  for (let attempt = 0; ; attempt++) {
+    try {
+      res = await postJSON(urlStr, body, headers);
+    } catch (e) {
+      // Connection-level error (ETIMEDOUT, ECONNRESET)
+      lastError = e;
+      if (attempt >= RUN_OPTS.max_retries) return { error: lastError };
+      await delay(attempt + 1);
+      continue;
+    }
+    if (res.status < 500 && res.status !== 429) return { res };
+    if (attempt >= RUN_OPTS.max_retries) return { res };
+    await delay(attempt + 1);
+  }
+}
+
 async function callOpenAICompat(provider, model, system, user) {
   const start = Date.now();
   const url = `${provider.baseUrl}/chat/completions`;
@@ -93,26 +113,9 @@ async function callOpenAICompat(provider, model, system, user) {
   };
   const authHeaders = { Authorization: `Bearer ${process.env[provider.envKey]}` };
 
-  let res;
-  let attempt = 0;
-  while (true) {
-    try {
-      res = await postJSON(url, payload, authHeaders);
-    } catch (e) {
-      // Connection-level error (ETIMEDOUT, ECONNRESET)
-      if (attempt >= RUN_OPTS.max_retries) {
-        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
-      }
-      attempt += 1;
-      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-      continue;
-    }
-    if (res.status < 500 && res.status !== 429) break;
-    if (attempt >= RUN_OPTS.max_retries) break;
-    attempt += 1;
-    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-  }
+  const { res, error } = await postJSONWithRetry(url, payload, authHeaders);
   const elapsed = Date.now() - start;
+  if (error) return { success: false, content: `[ERROR connection: ${error.code || error.message}]`, model, latency_ms: elapsed };
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
   try { data = JSON.parse(res.body); } catch (e) { return { success: false, content: `[parse-error]`, model, latency_ms: elapsed }; }
@@ -134,25 +137,9 @@ async function callAnthropic(provider, model, system, user) {
     'anthropic-version': '2023-06-01',
   };
 
-  let res;
-  let attempt = 0;
-  while (true) {
-    try {
-      res = await postJSON(url, payload, authHeaders);
-    } catch (e) {
-      if (attempt >= RUN_OPTS.max_retries) {
-        return { success: false, content: `[ERROR connection: ${e.code || e.message}]`, model, latency_ms: Date.now() - start };
-      }
-      attempt += 1;
-      await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-      continue;
-    }
-    if (res.status < 500 && res.status !== 429) break;
-    if (attempt >= RUN_OPTS.max_retries) break;
-    attempt += 1;
-    await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
-  }
+  const { res, error } = await postJSONWithRetry(url, payload, authHeaders);
   const elapsed = Date.now() - start;
+  if (error) return { success: false, content: `[ERROR connection: ${error.code || error.message}]`, model, latency_ms: elapsed };
   if (res.status >= 400) return { success: false, content: `[ERROR ${res.status}: ${res.body.slice(0, 300)}]`, model, latency_ms: elapsed };
   let data;
   try { data = JSON.parse(res.body); } catch { return { success: false, content: '[parse-error]', model, latency_ms: elapsed }; }

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -331,7 +331,7 @@ function usage() {
 Options:
   --max-tokens   Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)
   --timeout      HTTP request timeout in ms (default 120000; bump to 300000+ for slow NIM endpoints)
-  --max-retries  Retry count on 429/5xx (default 1; exponential backoff 2s, 4s, ...)
+  --max-retries  Retry count on connection errors and 429/5xx (default 1; exponential backoff 2s, 4s, ...)
   --sequential   Run model calls one at a time instead of in parallel (use when free endpoints
                  like NVIDIA NIM reject concurrent requests with ETIMEDOUT / 429)`);
   process.exit(1);

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -133,7 +133,7 @@ async function callAnthropic(provider, model, system, user) {
     system,
     messages: [{ role: 'user', content: user }],
   };
-  if (RUN_OPTS.reasoning_effort) payload.thinking = { type: 'enabled', budget_tokens: Math.min(RUN_OPTS.max_tokens * 0.8, 16000) };
+  if (RUN_OPTS.reasoning_effort) payload.thinking = { type: 'adaptive' };
   const authHeaders = {
     'x-api-key': process.env[provider.envKey],
     'anthropic-version': '2023-06-01',
@@ -210,7 +210,14 @@ function parseIntSafe(val, name) {
   if (args.timeout) RUN_OPTS.timeout_ms = parseIntSafe(args.timeout, 'timeout');
   if (args['max-retries']) RUN_OPTS.max_retries = parseIntSafe(args['max-retries'], 'max-retries');
   if (args.sequential) RUN_OPTS.sequential = true;
-  if (args['reasoning-effort']) RUN_OPTS.reasoning_effort = args['reasoning-effort'];
+  if (args['reasoning-effort']) {
+    const effort = args['reasoning-effort'];
+    if (!['low', 'medium', 'high'].includes(effort)) {
+      console.error(`Invalid --reasoning-effort: ${effort} (must be low, medium, or high)`);
+      process.exit(2);
+    }
+    RUN_OPTS.reasoning_effort = effort;
+  }
 
   // Run a list of async callables either in parallel (default) or sequentially.
   // Sequential mode avoids concurrent-request limits on free NIM/OpenRouter endpoints.

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -209,9 +209,17 @@ async function cmdRun(args) {
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
 
-  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
-  if (args.timeout) RUN_OPTS.timeout_ms = parseInt(args.timeout, 10);
-  if (args['max-retries']) RUN_OPTS.max_retries = parseInt(args['max-retries'], 10);
+  function parseIntSafe(val, name) {
+    const n = parseInt(val, 10);
+    if (isNaN(n) || n <= 0 || n !== Math.floor(n)) {
+      console.error(`Invalid --${name}: ${val} (must be a positive integer)`);
+      process.exit(2);
+    }
+    return n;
+  }
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseIntSafe(args['max-tokens'], 'max-tokens');
+  if (args.timeout) RUN_OPTS.timeout_ms = parseIntSafe(args.timeout, 'timeout');
+  if (args['max-retries']) RUN_OPTS.max_retries = parseIntSafe(args['max-retries'], 'max-retries');
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;

--- a/skills/llm-council/scripts/council.js
+++ b/skills/llm-council/scripts/council.js
@@ -57,6 +57,10 @@ function pickProvider(arg) {
   return null;
 }
 
+// Runtime tuning knobs that can be overridden via CLI flags in `cmdRun`.
+// Defaults preserve previous hard-coded behavior.
+const RUN_OPTS = { max_tokens: 4000 };
+
 function postJSON(urlStr, body, headers, timeoutMs = 120000) {
   return new Promise((resolve, reject) => {
     const url = new URL(urlStr);
@@ -84,7 +88,7 @@ async function callOpenAICompat(provider, model, system, user) {
   const res = await postJSON(url, {
     model,
     messages: [{ role: 'system', content: system }, { role: 'user', content: user }],
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     temperature: 1,
   }, { Authorization: `Bearer ${process.env[provider.envKey]}` });
   const elapsed = Date.now() - start;
@@ -100,7 +104,7 @@ async function callAnthropic(provider, model, system, user) {
   const url = `${provider.baseUrl}/v1/messages`;
   const res = await postJSON(url, {
     model,
-    max_tokens: 4000,
+    max_tokens: RUN_OPTS.max_tokens,
     system,
     messages: [{ role: 'user', content: user }],
   }, {
@@ -163,6 +167,8 @@ async function cmdRun(args) {
   if (!providerName) { console.error('No provider env var set. Try ANTHROPIC_API_KEY or OPENAI_API_KEY.'); process.exit(2); }
   const provider = PROVIDERS[providerName];
   if (!provider.baseUrl) { console.error(`provider ${providerName} requires LLM_COUNCIL_BASE_URL`); process.exit(2); }
+
+  if (args['max-tokens']) RUN_OPTS.max_tokens = parseInt(args['max-tokens'], 10);
 
   const models = (args.models ? String(args.models).split(',') : provider.defaultModels).filter(Boolean);
   const chairman = args.chairman || provider.defaultChairman;
@@ -266,9 +272,12 @@ function cmdShow(args) {
 
 function usage() {
   console.error(`Usage:
-  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug]
+  council.js run "<query>" [--models id1,id2,id3] [--chairman id] [--provider name] [--wiki slug] [--max-tokens N]
   council.js providers
-  council.js show <session-id>`);
+  council.js show <session-id>
+
+Options:
+  --max-tokens  Max output tokens per model call (default 4000; bump to 16000+ for reasoning models)`);
   process.exit(1);
 }
 


### PR DESCRIPTION
Depends on #95.
Fixes #96.

## What

Modern reasoning models (OpenAI o1/o3, DeepSeek R1/V4, Claude with thinking) accept a `reasoning_effort` parameter that controls how much compute they spend on internal reasoning. Without it, models either waste tokens on simple queries or truncate reasoning on complex ones.

## Change

- Add `reasoning_effort: null` to `RUN_OPTS`
- In `callOpenAICompat`: add `reasoning: { effort }` to payload when set
- In `callAnthropic`: add `thinking: { type: 'enabled', budget_tokens }` when set (budget = min(max_tokens * 0.8, 16000))
- Parse `--reasoning-effort low|medium|high` in `cmdRun`
- Document in `usage()`

## After this PR

```bash
node council.js run "<query>" --models "..." --chairman "..." --reasoning-effort high
```

Diff: 12 +, 6 -.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable options for token limits, request timeouts, retries, execution order, and reasoning effort.
  * Added sequential execution support, while parallel processing remains the default for faster council runs.
  * Added automatic retries with exponential backoff for connection failures, rate limits, and server errors.
  * Improved reporting when connections fail.
  * Documented the new command-line options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->